### PR TITLE
fix: show gynecological fields on form load when female gender is pre-selected (SMA-745)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,8 +40,8 @@ android {
         applicationId = "com.skgtecnologia.sisem"
         minSdk = 30
         targetSdk = 36
-        versionCode = 80
-        versionName = "2.3.7"
+        versionCode = 81
+        versionName = "2.3.8"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/skgtecnologia/sisem/ui/medicalhistory/create/MedicalHistoryViewModel.kt
+++ b/app/src/main/java/com/skgtecnologia/sisem/ui/medicalhistory/create/MedicalHistoryViewModel.kt
@@ -330,6 +330,13 @@ class MedicalHistoryViewModel @Inject constructor(
                         )
                     }
 
+                    if (chipSelectionValues.containsKey(GENDER_IDENTIFIER)) {
+                        updatedBody = updateGynae(
+                            chipSelectionValues[GENDER_IDENTIFIER]?.id.orEmpty(),
+                            updatedBody
+                        )
+                    }
+
                     withContext(Dispatchers.Main) {
                         uiState = uiState.copy(
                             isLoading = false,
@@ -596,12 +603,12 @@ class MedicalHistoryViewModel @Inject constructor(
         uiModels: List<BodyRowModel>? = uiState.screenModel?.body,
         age: String? = null
     ): List<BodyRowModel> {
-        val ageTypeField = uiState.screenModel?.body
+        val ageTypeField = uiModels
             ?.firstOrNull { it.identifier == AGE_TYPE_IDENTIFIER } as ChipSelectionUiModel
         val ageType = ageTypeField.selected
 
         val ageFieldValue = if (age.isNullOrEmpty()) {
-            val ageField = uiState.screenModel?.body
+            val ageField = uiModels
                 ?.firstOrNull { it.identifier == AGE_IDENTIFIER } as TextFieldUiModel
             ageField.text
         } else {


### PR DESCRIPTION
## Summary

- `updateGynae()` was only called on user interaction, so gynecological fields stayed hidden when the form loaded with Femenino already selected server-side
- Refactored `updateGynae()` to read `ageTypeField` and `ageField` from its `uiModels` parameter instead of `uiState.screenModel?.body`, making it safe to call before the screen model is set in state
- Added a call to `updateGynae()` in the init block after `getFormInitialValues()` when a gender is pre-selected, so visibility is correct on first render

## Test plan

- [x] `MedicalHistoryViewModelTest` passes (verified locally)
- [ ] Manual test: open medical history form with female patient pre-selected — gynecological fields should be visible immediately on load
- [ ] Manual test: open medical history form with male patient pre-selected — gynecological fields should remain hidden

Fixes [SMA-745](https://skgtecnologia.atlassian.net/browse/SMA-745)

🤖 Generated with [Claude Code](https://claude.com/claude-code)