### PR TITLE
fix: prevent NumberFormatException in updateGynae when age is empty and bump version to 2.3.9 (82)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,8 +40,8 @@ android {
         applicationId = "com.skgtecnologia.sisem"
         minSdk = 30
         targetSdk = 36
-        versionCode = 81
-        versionName = "2.3.8"
+        versionCode = 82
+        versionName = "2.3.9"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/skgtecnologia/sisem/ui/medicalhistory/create/MedicalHistoryViewModel.kt
+++ b/app/src/main/java/com/skgtecnologia/sisem/ui/medicalhistory/create/MedicalHistoryViewModel.kt
@@ -619,7 +619,7 @@ class MedicalHistoryViewModel @Inject constructor(
 
         val isFemale = gender == FEMALE_GENDER_ID || gender == FEMALE_GENDER
         val showGynae =
-            isFemale && ageFieldValue.toInt() in GYNAE_AGE_LOWER_LIMIT..GYNAE_AGE_UPPER_LIMIT
+            isFemale && (ageFieldValue.toIntOrNull() ?: 0) in GYNAE_AGE_LOWER_LIMIT..GYNAE_AGE_UPPER_LIMIT
 
        return buildList {
            val updateBodyModel = updateBodyModel(


### PR DESCRIPTION
## Summary

- `updateGynae()` called `ageFieldValue.toInt()` which throws `NumberFormatException` when the age field is empty on initial form load
- Replaced with `toIntOrNull() ?: 0` — an unparseable age safely falls outside the `9..50` gynae range instead of crashing
- Version bump: 2.3.8 (81) → 2.3.9 (82)

## Test plan

- [x] `MedicalHistoryViewModelTest` passes locally
- [x] Open APH form for a female patient with no age pre-filled — should not crash
- [x] Open APH form for a female patient with age in 9–50 range — gynae fields should show
- [x] Open APH form for a female patient with age outside 9–50 — gynae fields should be hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)