### PR TITLE
fix: restore auth state when opening app from push notification on cold start

### DIFF
--- a/app/src/main/java/com/skgtecnologia/sisem/data/notification/NotificationsManager.kt
+++ b/app/src/main/java/com/skgtecnologia/sisem/data/notification/NotificationsManager.kt
@@ -10,7 +10,7 @@ import android.os.Bundle
 import androidx.core.app.NotificationCompat
 import com.skgtecnologia.sisem.R
 import com.skgtecnologia.sisem.commons.communication.NotificationEventHandler
-import com.skgtecnologia.sisem.ui.MainActivity
+import com.skgtecnologia.sisem.ui.splash.SplashActivity
 import com.valkiria.uicomponents.bricks.notification.model.NotificationData
 import com.valkiria.uicomponents.bricks.notification.model.NotificationType
 import com.valkiria.uicomponents.bricks.notification.model.getNotificationDataByType
@@ -26,7 +26,7 @@ class NotificationsManager @Inject constructor(private val context: Context) {
     fun buildNotificationData(notificationDataMap: Map<String, String>): NotificationData? {
         val notificationData = getNotificationDataByType(notificationDataMap)
 
-        val intent = Intent(context, MainActivity::class.java).apply {
+        val intent = Intent(context, SplashActivity::class.java).apply {
             when (notificationData?.notificationType) {
                 NotificationType.INCIDENT_ASSIGNED -> {
                     val bundle = Bundle()

--- a/app/src/main/java/com/skgtecnologia/sisem/ui/MainActivity.kt
+++ b/app/src/main/java/com/skgtecnologia/sisem/ui/MainActivity.kt
@@ -111,6 +111,7 @@ class MainActivity : FragmentActivity() {
             val intent = Intent(packageContext, MainActivity::class.java).apply {
                 putExtra(STARTUP_NAVIGATION_MODEL, model)
                 bundle?.let { putExtras(it) }
+                addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP)
             }
 
             packageContext.startActivity(intent)

--- a/app/src/main/java/com/skgtecnologia/sisem/ui/authcards/create/AuthCardsScreen.kt
+++ b/app/src/main/java/com/skgtecnologia/sisem/ui/authcards/create/AuthCardsScreen.kt
@@ -36,7 +36,6 @@ import com.valkiria.uicomponents.bricks.bottomsheet.BottomSheetView
 import com.valkiria.uicomponents.bricks.loader.OnLoadingHandler
 import com.valkiria.uicomponents.bricks.notification.OnNotificationHandler
 import com.valkiria.uicomponents.bricks.notification.model.NotificationData
-import kotlinx.coroutines.launch
 import timber.log.Timber
 
 @Composable
@@ -141,7 +140,7 @@ private fun AuthCardsScreenRender(
     }
 
     uiState.reportDetail?.let {
-        scope.launch { sheetState.show() }
+        LaunchedEffect(it) { sheetState.show() }
 
         BottomSheetView(
             content = { ReportDetailContent(model = uiState.reportDetail) },
@@ -153,7 +152,7 @@ private fun AuthCardsScreenRender(
     }
 
     uiState.chipSection?.let {
-        scope.launch { sheetState.show() }
+        LaunchedEffect(it) { sheetState.show() }
 
         BottomSheetView(
             content = {

--- a/app/src/main/java/com/skgtecnologia/sisem/ui/authcards/view/AuthCardViewScreen.kt
+++ b/app/src/main/java/com/skgtecnologia/sisem/ui/authcards/view/AuthCardViewScreen.kt
@@ -90,7 +90,7 @@ fun AuthCardViewScreen(
     }
 
     uiState.reportDetail?.let {
-        scope.launch { sheetState.show() }
+        LaunchedEffect(it) { sheetState.show() }
 
         BottomSheetView(
             content = { ReportDetailContent(model = uiState.reportDetail) },
@@ -102,7 +102,7 @@ fun AuthCardViewScreen(
     }
 
     uiState.chipSection?.let {
-        scope.launch { sheetState.show() }
+        LaunchedEffect(it) { sheetState.show() }
 
         BottomSheetView(
             content = {

--- a/app/src/main/java/com/skgtecnologia/sisem/ui/login/LoginScreen.kt
+++ b/app/src/main/java/com/skgtecnologia/sisem/ui/login/LoginScreen.kt
@@ -78,7 +78,7 @@ fun LoginScreen(
     }
 
     uiState.onLoginLink?.let { link ->
-        scope.launch { sheetState.show() }
+        LaunchedEffect(link) { sheetState.show() }
 
         BottomSheetView(
             content = { LegalContent(uiModel = link.toLegalContentModel()) },

--- a/app/src/main/java/com/skgtecnologia/sisem/ui/preoperational/view/PreOperationalViewScreen.kt
+++ b/app/src/main/java/com/skgtecnologia/sisem/ui/preoperational/view/PreOperationalViewScreen.kt
@@ -59,7 +59,7 @@ fun PreOperationalViewScreen(
     }
 
     uiState.findingDetail?.let {
-        scope.launch { sheetState.show() }
+        LaunchedEffect(it) { sheetState.show() }
 
         BottomSheetView(
             content = { FindingDetailContent(model = uiState.findingDetail) },


### PR DESCRIPTION
## Problem

When the app process was killed and a user tapped a push notification, the app always showed the authentication screen despite having a valid cached session token.

**Root cause:** The notification `PendingIntent` in `NotificationsManager` pointed directly to `MainActivity`. On cold start, `MainActivity.onCreate()` received no `STARTUP_NAVIGATION_MODEL` extra, causing `NavigationCoordinator.getAppStartDestination(null)` to always return `AuthGraph`.

**Why foreground was unaffected:** When the app was running, `FLAG_ACTIVITY_CLEAR_TOP` just brought the existing `MainActivity` to front without re-triggering `onCreate()`.

## Fix

**`NotificationsManager.kt`** — Changed `PendingIntent` target from `MainActivity` to `SplashActivity`. `SplashActivity` already calls `GetStartupState` (reads cached token from DB) and forwards `intent.extras` (notification bundle) to `launchMainActivity`, so notification data is preserved through the hop.

**`MainActivity.launchMainActivity()`** — Added `FLAG_ACTIVITY_CLEAR_TOP | FLAG_ACTIVITY_SINGLE_TOP` to prevent stacking a second `MainActivity` instance when the app is backgrounded (not killed) and the user taps a notification.

**Also fixed** pre-existing `CoroutineCreationDuringComposition` lint errors (`scope.launch → LaunchedEffect`) in `AuthCardsScreen`, `AuthCardViewScreen`, `PreOperationalViewScreen`, and `LoginScreen`.

## Test plan

- [ ] Kill the app completely (force-stop or swipe away)
- [ ] Send a push notification
- [ ] Tap the notification — user should land on the authenticated map screen, not the login screen
- [ ] Repeat with app backgrounded (not killed) — should also land on authenticated screen
- [ ] Verify app launched normally (icon tap) still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)