### PR TITLE
fix: resolve IME keyboard overlap on Android 15 (adjustResize deprecated)

### DIFF
--- a/app/src/main/java/com/skgtecnologia/sisem/ui/MainActivity.kt
+++ b/app/src/main/java/com/skgtecnologia/sisem/ui/MainActivity.kt
@@ -6,6 +6,7 @@ import android.os.Build
 import android.os.Bundle
 import android.view.WindowManager
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
@@ -52,6 +53,7 @@ class MainActivity : FragmentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
 
         // Prevent Screenshots on all build types but debug
         if (BuildConfig.BUILD_TYPE != "debug") {

--- a/app/src/main/java/com/skgtecnologia/sisem/ui/authcards/create/AuthCardsScreen.kt
+++ b/app/src/main/java/com/skgtecnologia/sisem/ui/authcards/create/AuthCardsScreen.kt
@@ -36,7 +36,6 @@ import com.valkiria.uicomponents.bricks.bottomsheet.BottomSheetView
 import com.valkiria.uicomponents.bricks.loader.OnLoadingHandler
 import com.valkiria.uicomponents.bricks.notification.OnNotificationHandler
 import com.valkiria.uicomponents.bricks.notification.model.NotificationData
-import kotlinx.coroutines.launch
 import timber.log.Timber
 
 @Composable
@@ -141,7 +140,7 @@ private fun AuthCardsScreenRender(
     }
 
     uiState.reportDetail?.let {
-        scope.launch { sheetState.show() }
+        LaunchedEffect(it) { sheetState.show() }
 
         BottomSheetView(
             content = { ReportDetailContent(model = uiState.reportDetail) },
@@ -153,7 +152,7 @@ private fun AuthCardsScreenRender(
     }
 
     uiState.chipSection?.let {
-        scope.launch { sheetState.show() }
+        LaunchedEffect(it) { sheetState.show() }
 
         BottomSheetView(
             content = {

--- a/app/src/main/java/com/skgtecnologia/sisem/ui/authcards/view/AuthCardViewScreen.kt
+++ b/app/src/main/java/com/skgtecnologia/sisem/ui/authcards/view/AuthCardViewScreen.kt
@@ -90,7 +90,7 @@ fun AuthCardViewScreen(
     }
 
     uiState.reportDetail?.let {
-        scope.launch { sheetState.show() }
+        LaunchedEffect(it) { sheetState.show() }
 
         BottomSheetView(
             content = { ReportDetailContent(model = uiState.reportDetail) },
@@ -102,7 +102,7 @@ fun AuthCardViewScreen(
     }
 
     uiState.chipSection?.let {
-        scope.launch { sheetState.show() }
+        LaunchedEffect(it) { sheetState.show() }
 
         BottomSheetView(
             content = {

--- a/app/src/main/java/com/skgtecnologia/sisem/ui/login/LoginScreen.kt
+++ b/app/src/main/java/com/skgtecnologia/sisem/ui/login/LoginScreen.kt
@@ -78,7 +78,7 @@ fun LoginScreen(
     }
 
     uiState.onLoginLink?.let { link ->
-        scope.launch { sheetState.show() }
+        LaunchedEffect(link) { sheetState.show() }
 
         BottomSheetView(
             content = { LegalContent(uiModel = link.toLegalContentModel()) },

--- a/app/src/main/java/com/skgtecnologia/sisem/ui/preoperational/view/PreOperationalViewScreen.kt
+++ b/app/src/main/java/com/skgtecnologia/sisem/ui/preoperational/view/PreOperationalViewScreen.kt
@@ -59,7 +59,7 @@ fun PreOperationalViewScreen(
     }
 
     uiState.findingDetail?.let {
-        scope.launch { sheetState.show() }
+        LaunchedEffect(it) { sheetState.show() }
 
         BottomSheetView(
             content = { FindingDetailContent(model = uiState.findingDetail) },

--- a/app/src/main/java/com/skgtecnologia/sisem/ui/sections/BodySection.kt
+++ b/app/src/main/java/com/skgtecnologia/sisem/ui/sections/BodySection.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
@@ -149,7 +150,7 @@ fun BodySection(
             }
 
             LazyColumn(
-                modifier = updatedModifier,
+                modifier = updatedModifier.imePadding(),
                 state = listState,
                 contentPadding = PaddingValues(horizontal = 20.dp, vertical = 8.dp),
                 verticalArrangement = Arrangement.spacedBy(0.dp, Alignment.Top),


### PR DESCRIPTION
## Problem

On Android 15 (API 35+), apps targeting API 35+ have **`adjustResize` deprecated**. The keyboard no longer resizes the window — it overlays the content instead. This caused the password field and login button to be hidden behind the keyboard with no way to scroll to them.

The app targets SDK 36, so all Android 15+ users hit this bug.

## Root cause

Two gaps:
1. `MainActivity` never called `enableEdgeToEdge()`, so Compose wasn't receiving correct IME insets on all API levels
2. The `LazyColumn` in `BodySection` had no `imePadding()`, so it didn't know to shrink its scrollable area when the keyboard appeared

## Fix

**`MainActivity.kt`** — Added `enableEdgeToEdge()` immediately after `super.onCreate()`. This opts the window into proper inset delivery on API 30–35+, replacing the now-deprecated `adjustResize` behavior.

**`BodySection.kt`** — Added `Modifier.imePadding()` to the `LazyColumn`. This adds bottom padding equal to the current keyboard height, so all form fields (password, buttons) remain reachable by scrolling above the keyboard.

**Also fixed** pre-existing `CoroutineCreationDuringComposition` lint errors (`scope.launch → LaunchedEffect`) in `AuthCardsScreen`, `AuthCardViewScreen`, `PreOperationalViewScreen`, and `LoginScreen`.

## Test plan

- [ ] Open login screen on Android 15 device / emulator
- [ ] Tap the **Usuario** field — keyboard appears
- [ ] Scroll down — **Contraseña** field and **Ingresar** button are reachable
- [ ] Tap the **Contraseña** field — keyboard stays open, field stays visible
- [ ] Verify same behavior on Android 12–14 (regression check)
- [ ] Verify the rest of the app (map, forms) renders correctly with edge-to-edge enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)