### PR TITLE
docs: add aph-stretcher-retention bug report + testing guide

### DIFF
--- a/documentation/bug-aph-stretcher-retention.md
+++ b/documentation/bug-aph-stretcher-retention.md
@@ -1,0 +1,66 @@
+# Bug — `POST /screen/aph-stretcher-retention` no responde (timeout)
+
+Reporte para escalar al equipo backend de SISEM. La app Android (v2.4.0) muestra el banner *"Servicio no disponible — Sucedió algo inesperado, por favor intenta de nuevo"* al entrar a **Registra retención de camilla → seleccionar paciente**. La causa raíz es un timeout del lado servidor; el comportamiento del cliente es correcto.
+
+## Endpoint afectado
+
+```
+POST https://api.emergencias.saludcapital.gov.co/sisem-api/v1/screen/aph-stretcher-retention
+Content-Type: application/json
+Body: {"params":{"id_aph":"77"}}
+```
+
+## Síntoma
+
+La request **no responde nunca**. El cliente OkHttp corta a los 15 s con `SocketTimeoutException` (timeout configurado en `app/src/main/java/com/skgtecnologia/sisem/di/CoreNetworkModule.kt:59`, aplicado en `BearerNetworkModule.kt:35-37`).
+
+## Evidencia reproducida (2026-05-11 11:40, hora Bogotá)
+
+Sobre staging (`api.emergencias.saludcapital.gov.co`), build `com.skgtecnologia.sisem-v2.4.0-83-staging`, usuario `oauxiliar`:
+
+```
+11:40:42.695  --> POST .../screen/aph-stretcher-retention   body={"params":{"id_aph":"77"}}
+11:40:57.838  <-- HTTP FAILED: java.net.SocketTimeoutException (15.141 ms)
+11:40:57.897  E/StretcherRetentionViewModel: This is a failure
+              BannerModel(title=Servicio no disponible,
+                          description=Sucedió algo inesperado, por favor intenta de nuevo)
+```
+
+La llamada inmediatamente anterior funciona OK con la misma sesión / token:
+
+```
+11:40:17.804  --> POST .../screen/pre-aph-stretcher-retention   body={"params":{"id_incident":"104"}}
+11:40:19.454  <-- 200 OK (1.634 ms, 578 B)
+```
+
+→ El problema está aislado al endpoint `aph-stretcher-retention`, no es de red ni de auth.
+
+## Contexto de prueba
+
+| Dato            | Valor                                                 |
+|-----------------|-------------------------------------------------------|
+| Ambiente        | `api.emergencias.saludcapital.gov.co`                 |
+| Build           | `com.skgtecnologia.sisem-v2.4.0-83-staging`           |
+| Usuario         | `oauxiliar` (curso)                                   |
+| Vehículo        | JHS026 — serial Android `7ec2c127b2095132`            |
+| `id_incident`   | `104`                                                 |
+| `id_aph`        | `77` (ANGEL MARTIN)                                   |
+| `actorId` token | `13025`                                               |
+
+## Lo que necesitamos del backend
+
+1. Revisar el handler de `POST /screen/aph-stretcher-retention` — probablemente colgado en alguna query o dependencia downstream que no completa.
+2. Confirmar si reproduce con cualquier `id_aph` o solo con ciertos pacientes / incidentes.
+3. Logs del servicio entre `2026-05-11 16:40:42 UTC` y `2026-05-11 16:40:57 UTC` para correlacionar con la traza.
+
+## Lado cliente
+
+El comportamiento Android es correcto:
+- `OkHttpClient` con `connect/read/writeTimeout = 15_000 ms` (`CoreNetworkModule.kt:59`).
+- `SocketTimeoutException` mapeado a `error_server_title` / `error_server_description` en `NetworkApi.kt:87`.
+
+Una vez resuelto el backend, opcionalmente se puede mejorar la UX agregando un botón *"Reintentar"* en el banner para errores de timeout/server. No es bloqueante para destrabar el flujo.
+
+## Cómo reproducir localmente
+
+Ver `documentation/testing.md` — pasos completos para spoofear el Android ID con el serial `7ec2c127b2095132` y loguearse con los usuarios de curso.

--- a/documentation/testing.md
+++ b/documentation/testing.md
@@ -1,0 +1,119 @@
+# Testing Guide
+
+This document explains how to set up a local environment to reproduce QA scenarios on the SISEM Android app, including spoofing the device identifier (Android ID) so a fresh emulator can be paired against a known vehicle/AVL in the backend.
+
+## Build variant
+
+For QA against the Bogotá production-ish backend, use the **staging** variant — it points to `api.emergencias.saludcapital.gov.co`, same host the test users below live in.
+
+```bash
+./gradlew assembleStaging
+adb install -r app/build/outputs/apk/staging/com.skgtecnologia.sisem-v*.apk
+```
+
+| Variant   | Base URL                                      |
+|-----------|-----------------------------------------------|
+| debug     | test.emergencias-sisem.co                     |
+| staging   | api.emergencias.saludcapital.gov.co           |
+| preProd   | mobile-preprod.sisem.co                       |
+| release   | api.emergencias.saludcapital.gov.co           |
+
+## Test users (course role — "Cursos")
+
+| Role        | Username   | Password   |
+|-------------|-----------|------------|
+| Médico      | OMEDICO   | 22042601   |
+| Conductor   | OCONDUCTOR| 22042602   |
+| Auxiliar APH| OAUXILIAR | 22042603   |
+
+These users are tied to a vehicle that has been pre-registered in the backend with a specific device serial (see next section). If you try to log in from an emulator that the backend doesn't know, the device-auth screen blocks you.
+
+## Faking the Android ID (device serial)
+
+The vehicle/AVL is keyed by the device's Android ID, which the app reads through `AndroidIdProvider`:
+
+- Interface: `app/src/main/java/com/skgtecnologia/sisem/commons/resources/AndroidIdProvider.kt`
+- Impl: `app/src/main/java/com/skgtecnologia/sisem/commons/resources/AndroidIdProviderImpl.kt`
+
+How it works:
+
+1. On first read, the app creates `<app filesDir>/android_id`. If empty, it falls back to `Settings.Secure.ANDROID_ID` and caches the value inside that file.
+2. On every subsequent read it returns the cached value. So if you overwrite the file, the new value sticks until the app data is cleared.
+
+**Serial registered for the test users:** `7ec2c127b2095132`
+
+### Steps to inject it (emulator or rooted device)
+
+```bash
+# 1. Install + run the staging APK once so the app's filesDir exists
+adb install -r app/build/outputs/apk/staging/com.skgtecnologia.sisem-v*.apk
+adb shell am start -n com.skgtecnologia.sisem/.ui.MainActivity   # or just open it
+# Close the app after the first launch so the file is created.
+
+# 2. Force-stop and overwrite the cached android_id
+adb shell am force-stop com.skgtecnologia.sisem
+adb shell "run-as com.skgtecnologia.sisem sh -c 'printf 7ec2c127b2095132 > files/android_id'"
+
+# 3. Verify
+adb shell "run-as com.skgtecnologia.sisem cat files/android_id"
+# → 7ec2c127b2095132
+```
+
+> `run-as` only works on `debug`/`staging` builds (debuggable). For `release` you need root.
+
+If `run-as` is not available, push via a temp file:
+
+```bash
+echo -n "7ec2c127b2095132" > /tmp/android_id
+adb push /tmp/android_id /sdcard/android_id
+adb shell "run-as com.skgtecnologia.sisem cp /sdcard/android_id files/android_id"
+```
+
+### Resetting
+
+To go back to the real Android ID, just wipe app data — next launch will regenerate the file from `Settings.Secure.ANDROID_ID`:
+
+```bash
+adb shell pm clear com.skgtecnologia.sisem
+```
+
+## Reproducing the "Registra retención de camilla" failure
+
+This is the issue captured in `Desktop/Android/falla.mp4` (May 2026).
+
+### Steps
+
+1. Login with one of the test users above.
+2. Make sure the device has an active incident assigned (the side menu only shows "Registra retención de camilla" when there's an active operation with `id_aph`).
+3. Open the side drawer → tap **Registra retención de camilla**.
+4. The patient list loads (`POST /sisem-api/v1/screen/pre-aph-stretcher-retention` → 200 in ~200 ms).
+5. Tap a patient.
+6. Wait ~15 s. The form never loads and a red banner appears:
+   > **Servicio no disponible** — Sucedió algo inesperado, por favor intenta de nuevo
+
+### What's happening under the hood
+
+- The failing call is `POST /sisem-api/v1/screen/aph-stretcher-retention` with body `{"params":{"id_aph":"<id>"}}` (see `StretcherRetentionApi.kt:17`, `StretcherRetentionRemoteDataSource.kt:31`).
+- OkHttp client timeout for bearer-authenticated calls is **15 s** — `di/CoreNetworkModule.kt:59` (`CLIENT_TIMEOUT_DEFAULTS = 15_000L`) wired in `di/BearerNetworkModule.kt:35`.
+- The Network Inspector shows the request hanging the full 15 s with **no status code** and an empty response — i.e. `SocketTimeoutException`.
+- `NetworkApi.parseError` (`data/remote/api/NetworkApi.kt:87`) maps `SocketTimeoutException` to the strings `error_server_title` / `error_server_description`, which is exactly the banner from the video (`res/values/strings.xml:29-30`).
+
+**Diagnosis:** Backend regression. The `aph-stretcher-retention` endpoint is not responding within 15 s for the `id_aph` returned by `pre-aph-stretcher-retention`. The Android side is behaving correctly (it surfaces a server-error banner instead of hanging forever).
+
+### Useful inspection commands while reproducing
+
+```bash
+# Tail app logs
+adb logcat -s SISEM:* OkHttp:* AndroidRuntime:E
+
+# Watch the cached network log written by NetworkApi.storeSuccessResponse / storeErrorResponse
+adb shell "run-as com.skgtecnologia.sisem cat files/android_networking.txt"
+```
+
+(See `ANDROID_NETWORKING_FILE_NAME` in `commons/resources/`.)
+
+## Notes for future tests
+
+- Always force-stop the app after rewriting `files/android_id` — the value is read on demand but cached in memory after the first call.
+- The `pre-aph-stretcher-retention` call also depends on the **active incident** held in `IncidentCacheDataSource`. If you wipe app data you'll need to re-login *and* have a fresh incident assigned, otherwise the pre-screen shows the empty state (`emptyStretcherRetentionHeader()`).
+- Test users for the `Cursos` course role share the same vehicle serial, so all three can sign in on the same emulator if you switch sessions.


### PR DESCRIPTION
## Summary

Adds two documentation files:
- `documentation/testing.md` — guide to spoof the Android ID via `AndroidIdProvider` for the Cursos test users (`OMEDICO`/`OCONDUCTOR`/`OAUXILIAR`) on vehicle JHS026 (serial `7ec2c127b2095132`).
- `documentation/bug-aph-stretcher-retention.md` — backend-side timeout report (see below) reproduced end-to-end on 2026-05-11.

This PR is documentation-only; it surfaces a backend issue we need to escalate.

---

## Bug — `POST /screen/aph-stretcher-retention` no responde (timeout)

### Endpoint afectado

```
POST https://api.emergencias.saludcapital.gov.co/sisem-api/v1/screen/aph-stretcher-retention
Content-Type: application/json
Body: {"params":{"id_aph":"77"}}
```

### Síntoma

La request no responde nunca. El cliente OkHttp corta a los 15 s con `SocketTimeoutException` (timeout configurado en `app/src/main/java/com/skgtecnologia/sisem/di/CoreNetworkModule.kt:59`, aplicado en `BearerNetworkModule.kt:35-37`). En la UI esto se traduce en el banner *"Servicio no disponible — Sucedió algo inesperado, por favor intenta de nuevo"* al entrar a **Registra retención de camilla → seleccionar paciente**.

### Evidencia reproducida (2026-05-11 11:40, hora Bogotá)

Staging (`api.emergencias.saludcapital.gov.co`), build `com.skgtecnologia.sisem-v2.4.0-83-staging`, usuario `oauxiliar`:

```
11:40:42.695  --> POST .../screen/aph-stretcher-retention   body={"params":{"id_aph":"77"}}
11:40:57.838  <-- HTTP FAILED: java.net.SocketTimeoutException (15.141 ms)
11:40:57.897  E/StretcherRetentionViewModel: This is a failure
              BannerModel(title=Servicio no disponible,
                          description=Sucedió algo inesperado, por favor intenta de nuevo)
```

La llamada inmediatamente anterior funciona OK con la misma sesión / token:

```
11:40:17.804  --> POST .../screen/pre-aph-stretcher-retention   body={"params":{"id_incident":"104"}}
11:40:19.454  <-- 200 OK (1.634 ms, 578 B)
```

→ Problema aislado al endpoint `aph-stretcher-retention`, no es de red ni de auth.

### Contexto de prueba

| Dato            | Valor                                                 |
|-----------------|-------------------------------------------------------|
| Ambiente        | `api.emergencias.saludcapital.gov.co`                 |
| Build           | `com.skgtecnologia.sisem-v2.4.0-83-staging`           |
| Usuario         | `oauxiliar` (curso)                                   |
| Vehículo        | JHS026 — serial Android `7ec2c127b2095132`            |
| `id_incident`   | `104`                                                 |
| `id_aph`        | `77` (ANGEL MARTIN)                                   |
| `actorId` token | `13025`                                               |

### Lo que necesitamos del backend

1. Revisar el handler de `POST /screen/aph-stretcher-retention` — probablemente colgado en alguna query o dependencia downstream que no completa.
2. Confirmar si reproduce con cualquier `id_aph` o solo con ciertos pacientes / incidentes.
3. Logs del servicio entre `2026-05-11 16:40:42 UTC` y `2026-05-11 16:40:57 UTC` para correlacionar.

### Lado cliente

Comportamiento Android correcto:
- `OkHttpClient` con `connect/read/writeTimeout = 15_000 ms` (`CoreNetworkModule.kt:59`).
- `SocketTimeoutException` → `error_server_title` / `error_server_description` en `NetworkApi.kt:87`.

Una vez resuelto el backend, opcional: agregar botón *"Reintentar"* en el banner para errores de timeout/server. No bloqueante.

## Test plan

- [ ] Lectura: validar que `documentation/testing.md` permita reproducir el flujo desde un emulador limpio.
- [ ] Lectura: validar que `documentation/bug-aph-stretcher-retention.md` tenga toda la info para escalar al backend.
- [ ] (Backend) Investigar la causa del timeout en `aph-stretcher-retention`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)