### PR TITLE
chore: bump version to 2.4.1 (84)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,8 +40,8 @@ android {
         applicationId = "com.skgtecnologia.sisem"
         minSdk = 30
         targetSdk = 36
-        versionCode = 83
-        versionName = "2.4.0"
+        versionCode = 84
+        versionName = "2.4.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {


### PR DESCRIPTION
## Summary

Bumps app version from `2.4.0 (83)` → `2.4.1 (84)`.

## Includes

Fixes merged after 2.4.0 (83):

- **#275** docs: testing guide + aph-stretcher-retention backend bug report.
- **#276** fix: register `androidx.hilt:hilt-compiler` so `HiltWorkerFactory` knows `LocationWorker`. Restores device location updates that were silently failing every 5 s (~2.2k worker creation errors per short session, 0 location POSTs reaching the backend). After the fix: 100% of POSTs to `/sisem-location-api/v1/location` succeed with backend 2xx.

## Test plan

- [ ] CI green.
- [ ] Manual smoke test on staging APK (`com.skgtecnologia.sisem-v2.4.1-84-staging`).
- [ ] Verify location POSTs fire every ~5 s in logcat (regression check on the PR #276 fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
