### PR TITLE
perf: low-hanging fruit (build, http cache, android-id cache, compose keys)

### DIFF
--- a/app/src/main/java/com/skgtecnologia/sisem/commons/resources/AndroidIdProviderImpl.kt
+++ b/app/src/main/java/com/skgtecnologia/sisem/commons/resources/AndroidIdProviderImpl.kt
@@ -6,33 +6,42 @@ import android.provider.Settings
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.io.File
 import javax.inject.Inject
+import javax.inject.Singleton
 
 private const val FILE_NAME = "android_id"
 
+@Singleton
 class AndroidIdProviderImpl @Inject constructor(
     @ApplicationContext private val context: Context
 ) : AndroidIdProvider {
 
+    @Volatile
+    private var cachedAndroidId: String? = null
+
     @SuppressLint("HardwareIds")
     override fun getAndroidId(): String {
-        var androidId: String
+        cachedAndroidId?.let { return it }
+        return synchronized(this) {
+            cachedAndroidId ?: readOrInitializeAndroidId().also { cachedAndroidId = it }
+        }
+    }
 
+    @SuppressLint("HardwareIds")
+    private fun readOrInitializeAndroidId(): String {
         File(context.filesDir, FILE_NAME).createNewFile()
 
-        context.openFileInput(FILE_NAME).use { input ->
-            androidId = input.readBytes().toString(Charsets.UTF_8)
+        val storedId = context.openFileInput(FILE_NAME).use { input ->
+            input.readBytes().toString(Charsets.UTF_8)
         }
+        if (storedId.isNotEmpty()) return storedId
 
-        if (androidId.isEmpty()) {
-            androidId = Settings.Secure
-                .getString(context.contentResolver, Settings.Secure.ANDROID_ID)
-                .orEmpty()
+        val fallback = Settings.Secure
+            .getString(context.contentResolver, Settings.Secure.ANDROID_ID)
+            .orEmpty()
 
-            context.openFileOutput(FILE_NAME, Context.MODE_PRIVATE).use { output ->
-                output.write(androidId.toByteArray())
-            }
+        context.openFileOutput(FILE_NAME, Context.MODE_PRIVATE).use { output ->
+            output.write(fallback.toByteArray())
         }
-
-        return androidId
+        return fallback
     }
 }

--- a/app/src/main/java/com/skgtecnologia/sisem/di/BearerNetworkModule.kt
+++ b/app/src/main/java/com/skgtecnologia/sisem/di/BearerNetworkModule.kt
@@ -1,5 +1,6 @@
 package com.skgtecnologia.sisem.di
 
+import android.content.Context
 import com.skgtecnologia.sisem.BuildConfig
 import com.skgtecnologia.sisem.data.remote.interceptors.AccessTokenAuthenticator
 import com.skgtecnologia.sisem.data.remote.interceptors.AccessTokenInterceptor
@@ -10,11 +11,14 @@ import com.squareup.moshi.Moshi
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import okhttp3.Cache
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
+import java.io.File
 import java.util.concurrent.TimeUnit
 import javax.inject.Singleton
 
@@ -25,13 +29,16 @@ object BearerNetworkModule {
     @BearerAuthentication
     @Singleton
     @Provides
+    @Suppress("LongParameterList")
     internal fun providesOkHttpClient(
+        @ApplicationContext context: Context,
         accessTokenAuthenticator: AccessTokenAuthenticator,
         accessTokenInterceptor: AccessTokenInterceptor,
         auditInterceptor: AuditInterceptor,
         loggingInterceptor: HttpLoggingInterceptor?,
         networkInterceptor: NetworkInterceptor
     ): OkHttpClient = OkHttpClient.Builder().apply {
+        cache(Cache(File(context.cacheDir, "http-bearer"), HTTP_CACHE_SIZE_BYTES))
         connectTimeout(CLIENT_TIMEOUT_DEFAULTS, TimeUnit.MILLISECONDS)
         readTimeout(CLIENT_TIMEOUT_DEFAULTS, TimeUnit.MILLISECONDS)
         writeTimeout(CLIENT_TIMEOUT_DEFAULTS, TimeUnit.MILLISECONDS)

--- a/app/src/main/java/com/skgtecnologia/sisem/di/CoreNetworkModule.kt
+++ b/app/src/main/java/com/skgtecnologia/sisem/di/CoreNetworkModule.kt
@@ -57,6 +57,7 @@ import okhttp3.logging.HttpLoggingInterceptor
 import javax.inject.Singleton
 
 const val CLIENT_TIMEOUT_DEFAULTS = 15_000L
+const val HTTP_CACHE_SIZE_BYTES: Long = 10L * 1024 * 1024 // 10 MB
 
 @Module
 @InstallIn(SingletonComponent::class)

--- a/app/src/main/java/com/skgtecnologia/sisem/di/auth/AuthNetworkModule.kt
+++ b/app/src/main/java/com/skgtecnologia/sisem/di/auth/AuthNetworkModule.kt
@@ -1,21 +1,26 @@
 package com.skgtecnologia.sisem.di.auth
 
+import android.content.Context
 import com.skgtecnologia.sisem.BuildConfig
 import com.skgtecnologia.sisem.data.auth.remote.AuthApi
 import com.skgtecnologia.sisem.data.remote.interceptors.AuditInterceptor
 import com.skgtecnologia.sisem.data.remote.interceptors.NetworkInterceptor
 import com.skgtecnologia.sisem.di.CLIENT_TIMEOUT_DEFAULTS
 import com.skgtecnologia.sisem.di.CoreNetworkModule
+import com.skgtecnologia.sisem.di.HTTP_CACHE_SIZE_BYTES
 import com.skgtecnologia.sisem.di.qualifiers.BasicAuthentication
 import com.squareup.moshi.Moshi
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import okhttp3.Cache
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
+import java.io.File
 import java.util.concurrent.TimeUnit
 import javax.inject.Singleton
 
@@ -27,10 +32,12 @@ object AuthNetworkModule {
     @Singleton
     @Provides
     internal fun providesOkHttpClient(
+        @ApplicationContext context: Context,
         loggingInterceptor: HttpLoggingInterceptor?,
         auditInterceptor: AuditInterceptor,
         networkInterceptor: NetworkInterceptor
     ): OkHttpClient = OkHttpClient.Builder().apply {
+        cache(Cache(File(context.cacheDir, "http-auth"), HTTP_CACHE_SIZE_BYTES))
         connectTimeout(CLIENT_TIMEOUT_DEFAULTS, TimeUnit.MILLISECONDS)
         readTimeout(CLIENT_TIMEOUT_DEFAULTS, TimeUnit.MILLISECONDS)
         writeTimeout(CLIENT_TIMEOUT_DEFAULTS, TimeUnit.MILLISECONDS)

--- a/app/src/main/java/com/skgtecnologia/sisem/ui/dropdown/DropDownContent.kt
+++ b/app/src/main/java/com/skgtecnologia/sisem/ui/dropdown/DropDownContent.kt
@@ -16,6 +16,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -64,6 +65,10 @@ fun DropDownContent(
             mutableStateOf(itemList.find { it.name == defaultSelected })
         }
 
+        val filteredItems by remember(itemList) {
+            derivedStateOf { itemList.filter { it.name.contains(text, ignoreCase = true) } }
+        }
+
         OutlinedTextField(
             modifier = Modifier
                 .constrainAs(searchHeader) {
@@ -106,9 +111,8 @@ fun DropDownContent(
                 verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 items(
-                    itemList.filter {
-                        it.name.contains(text, true)
-                    }
+                    items = filteredItems,
+                    key = { it.id }
                 ) {
                     Text(
                         modifier = Modifier
@@ -135,7 +139,7 @@ fun DropDownContent(
                 contentPadding = PaddingValues(horizontal = 20.dp, vertical = 8.dp),
                 verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                items(itemList) {
+                items(items = itemList, key = { it.id }) {
                     Text(
                         modifier = Modifier
                             .fillMaxWidth()

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,11 +6,11 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
-# When configured, Gradle will run in incubating parallel mode.
-# This option should only be used with decoupled projects. More details, visit
-# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
+org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
+# Build modules in parallel where dependencies allow.
+org.gradle.parallel=true
+# Reuse outputs across builds / branches.
+org.gradle.caching=true
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn

--- a/uicomponents/src/main/java/com/valkiria/uicomponents/components/chip/FiltersComponent.kt
+++ b/uicomponents/src/main/java/com/valkiria/uicomponents/components/chip/FiltersComponent.kt
@@ -62,7 +62,7 @@ fun FiltersComponent(
         horizontalArrangement = Arrangement.Center,
         verticalAlignment = Alignment.CenterVertically
     ) {
-        items(uiModel.options) { chipText ->
+        items(items = uiModel.options, key = { it }) { chipText ->
             val isSelected = chipText == selected
 
             FilterChipView(


### PR DESCRIPTION
## Summary

Four independent, small performance wins identified in a code review pass. Each is low-risk on its own and they are bundled because every change is 1–2 lines.

## Changes

### 1. Gradle build performance — `gradle.properties`

- `org.gradle.parallel=true` (was commented out).
- `org.gradle.caching=true`.
- `-Xmx2048m` → `-Xmx4096m` for the daemon JVM.

Local build wall-clock drops noticeably on multi-module incremental builds. CI may also benefit if the runner has multiple cores.

### 2. OkHttp response cache — `di/CoreNetworkModule.kt`, `di/BearerNetworkModule.kt`, `di/auth/AuthNetworkModule.kt`

Both clients now ship a 10 MB on-disk `Cache` rooted at `context.cacheDir/http-bearer` and `context.cacheDir/http-auth`. Previously neither OkHttpClient configured `.cache(...)`, so even responses with cache-friendly headers had to hit the network on every call.

### 3. AndroidIdProvider in-memory cache — `commons/resources/AndroidIdProviderImpl.kt`

Previously, every `getAndroidId()` call did two file operations (read, sometimes write). The method is invoked from many ViewModels during their `init` block (LoginVM, AuthCardsVM, DeviceAuthVM, InventoryVM, etc.), so it ran several times during a typical screen launch.

Now the class is `@Singleton` with a `@Volatile` cached value populated lazily via double-checked locking. First call still primes the cache via file I/O; every subsequent caller across the process gets the value back without any I/O.

### 4. Compose `Lazy*` stable item keys — `ui/dropdown/DropDownContent.kt`, `uicomponents/.../FiltersComponent.kt`

- Both `LazyColumn`s in `DropDownContent` now receive `key = { it.id }`. Scroll / filter recompositions reuse existing item nodes instead of re-creating them.
- The filtered list is wrapped in `derivedStateOf { ... }` so the filter only re-runs when `itemList` or the search `text` actually change.
- `FiltersComponent.items(uiModel.options)` now passes `key = { it }` so chip selection toggles do not force a full re-bind of the row.

## Validation

- [x] `./gradlew detekt ktlintCheck :app:testDebugUnitTest :uicomponents:testDebugUnitTest` — green locally.

## Out of scope (follow-up PRs)

Identified but intentionally not in this PR — each warrants its own change:

- Enabling R8 / `isMinifyEnabled = true` in `release` (massive APK size & cold-start win, but needs proguard-rule validation per dependency).
- Removing `runBlocking` from `AuditInterceptor` / `AccessTokenInterceptor` / `AccessTokenAuthenticator` (architectural refactor to avoid blocking the OkHttp dispatcher).
- Baseline profile module.
- Refactoring ViewModels that expose `mutableStateOf` to `StateFlow` for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
