### PR TITLE
perf: collect access token once in GetStartupState (splash path)

### DIFF
--- a/app/src/main/java/com/skgtecnologia/sisem/domain/operation/usecases/GetStartupState.kt
+++ b/app/src/main/java/com/skgtecnologia/sisem/domain/operation/usecases/GetStartupState.kt
@@ -16,19 +16,18 @@ class GetStartupState @Inject constructor(
 
     @CheckResult
     suspend operator fun invoke(): Result<StartupNavigationModel> = resultOf {
-        val accessToken = authRepository.observeCurrentAccessToken()
+        val token = authRepository.observeCurrentAccessToken().first()
         val operationConfig = getOperationConfigWithCurrentRole.invoke().getOrNull()
         val configPreoperational = PreoperationalStatus.getStatusByName(
             operationConfig?.vehicleConfig?.preoperational.orEmpty()
         ) == PreoperationalStatus.SI
 
         StartupNavigationModel(
-            isAdmin = accessToken.first()?.isAdmin == true,
-            isTurnStarted = accessToken.first()?.turn?.isComplete == true,
-            isWarning = accessToken.first()?.isWarning == true,
-            requiresPreOperational = accessToken.first()?.preoperational?.status == true &&
-                configPreoperational,
-            preOperationRole = OperationRole.getRoleByName(accessToken.first()?.role.orEmpty()),
+            isAdmin = token?.isAdmin == true,
+            isTurnStarted = token?.turn?.isComplete == true,
+            isWarning = token?.isWarning == true,
+            requiresPreOperational = token?.preoperational?.status == true && configPreoperational,
+            preOperationRole = OperationRole.getRoleByName(token?.role.orEmpty()),
             vehicleCode = operationConfig?.vehicleCode
         )
     }


### PR DESCRIPTION
## Summary

Tiny but real cold-start fix. `GetStartupState.invoke()` runs on the splash critical path (called from `SplashViewModel` while the splash screen is visible). The previous implementation collected the access-token Flow **5 separate times** — `accessToken.first()` is called once per field read.

Every `.first()` on `observeCurrentAccessToken()` rewinds the Flow from the source, so what should have been a single Room read became 5 round-trips through DAO + entity → domain mapping.

## Change

`domain/operation/usecases/GetStartupState.kt` — collect once, read the snapshot:

```kotlin
val token = authRepository.observeCurrentAccessToken().first()
// ...
isAdmin = token?.isAdmin == true,
isTurnStarted = token?.turn?.isComplete == true,
// etc.
```

Identical observable behavior: all reads happen inside the same suspend block, so there was never a use case for picking up an intermediate emission between fields.

## Validation

- [x] `./gradlew :app:compileDebugKotlin detekt ktlintCheck :app:testDebugUnitTest` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
