### PR TITLE
chore: bump version to 2.4.2 (85)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,8 +40,8 @@ android {
         applicationId = "com.skgtecnologia.sisem"
         minSdk = 30
         targetSdk = 36
-        versionCode = 84
-        versionName = "2.4.1"
+        versionCode = 85
+        versionName = "2.4.2"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {


### PR DESCRIPTION
## Summary

Bumps app version from `2.4.1 (84)` → `2.4.2 (85)`.

## Includes

User-facing fixes and improvements merged after `2.4.1 (84)`:

- **#279** fix: deliver FCM tap on existing MainActivity + offline location queue improvements. Background incident-assigned notifications now correctly update the in-app state, and the queued location samples preserve their capture timestamp + drop stale ones rather than flooding the backend with old positions.
- **#281** perf: low-hanging fruit — OkHttp response cache (10 MB), `AndroidIdProvider` in-memory cache (file I/O N→1 per process), stable `key=` on `LazyColumn`/`LazyRow` in `DropDownContent` / `FiltersComponent`, plus build-side speedups in `gradle.properties` (parallel + caching + 4 GB heap).
- **#282** perf: collapse 5 Room reads into 1 in `GetStartupState`, on the cold-start splash path.
- **#280** chore: bump Kotlin `2.3.10 → 2.3.21` and KSP `2.3.4 → 2.3.7`.
- **#278** fix: point QA (debug) build to the new `sisem.co` hostnames (`/qa/` path on the `staging` variant). Production unaffected.

## Test plan

- [ ] CI green.
- [ ] Smoke test release APK (`com.skgtecnologia.sisem-v2.4.2-85-release.apk`): cold start, login, mapa, drawer, push de incidente asignado en background → bottomsheet aparece al volver al foreground, location POSTs cada ~5 s con `origin_at` real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
