### PR TITLE
fix: break re-auth loop by deleting dead token on refresh failure

### DIFF
--- a/app/src/main/java/com/skgtecnologia/sisem/data/remote/interceptors/AccessTokenAuthenticator.kt
+++ b/app/src/main/java/com/skgtecnologia/sisem/data/remote/interceptors/AccessTokenAuthenticator.kt
@@ -140,6 +140,13 @@ class AccessTokenAuthenticator @Inject constructor(
                     ).toByteArray()
                 )
 
+                // Drop the dead token from the cache. If we keep it, the next
+                // 401-driven authenticate() call reads the same expired refresh
+                // token, fails again, and emits another UnauthorizedSession event
+                // — looping the user back to the login screen on every retry.
+                runBlocking {
+                    authRepository.deleteAccessTokenByUsername(currentToken.username)
+                }
                 UnauthorizedEventHandler.publishUnauthorizedEvent(currentToken.username)
                 return@synchronized null
             }

--- a/app/src/main/java/com/skgtecnologia/sisem/data/remote/interceptors/AccessTokenInterceptor.kt
+++ b/app/src/main/java/com/skgtecnologia/sisem/data/remote/interceptors/AccessTokenInterceptor.kt
@@ -8,6 +8,7 @@ import com.skgtecnologia.sisem.commons.resources.StorageProvider
 import com.skgtecnologia.sisem.data.remote.extensions.signWithToken
 import com.skgtecnologia.sisem.di.operation.OperationRole
 import com.skgtecnologia.sisem.domain.auth.AuthRepository
+import com.skgtecnologia.sisem.domain.auth.model.AccessTokenModel
 import com.skgtecnologia.sisem.domain.model.banner.BannerModel
 import com.valkiria.uicomponents.utlis.TimeUtils
 import kotlinx.coroutines.runBlocking
@@ -96,57 +97,81 @@ class AccessTokenInterceptor @Inject constructor(
     }
 
     private suspend fun Request.handleTokenExpirationTime() {
-        authRepository.getAllAccessTokens().map { accessTokenModel ->
-            if (LocalDateTime.now() > accessTokenModel.expDate) {
-                val authenticateContent = TimeUtils.getLocalDateTime(Instant.now()).toString() +
-                    "\t Authenticate intent: " + url +
-                    "\t with Token model: " + accessTokenModel +
-                    "\t using the refresh token: " + accessTokenModel.refreshToken +
-                    "\t refreshed on: " + accessTokenModel.refreshDateTime +
-                    "\n\n"
+        authRepository.getAllAccessTokens()
+            .filter { LocalDateTime.now() > it.expDate }
+            .forEach { refreshExpiredToken(it) }
+    }
 
-                storageProvider.storeContent(
-                    ANDROID_NETWORKING_FILE_NAME,
-                    Context.MODE_APPEND,
-                    authenticateContent.toByteArray()
-                )
+    private suspend fun Request.refreshExpiredToken(accessTokenModel: AccessTokenModel) {
+        val authenticateContent = TimeUtils.getLocalDateTime(Instant.now()).toString() +
+            "\t Authenticate intent: " + url +
+            "\t with Token model: " + accessTokenModel +
+            "\t using the refresh token: " + accessTokenModel.refreshToken +
+            "\t refreshed on: " + accessTokenModel.refreshDateTime +
+            "\n\n"
 
-                resultOf { authRepository.refreshToken(accessTokenModel) }
-                    .onSuccess { refreshedTokenModel ->
-                        val refreshSuccessfulContent =
-                            TimeUtils.getLocalDateTime(Instant.now()).toString() +
-                                "\t Refreshed Token model: " + refreshedTokenModel +
-                                "\t using the refresh token: " + accessTokenModel.refreshToken +
-                                "\t refreshed on: " + refreshedTokenModel.refreshDateTime +
-                                "\n\n"
+        storageProvider.storeContent(
+            ANDROID_NETWORKING_FILE_NAME,
+            Context.MODE_APPEND,
+            authenticateContent.toByteArray()
+        )
 
-                        storageProvider.storeContent(
-                            ANDROID_NETWORKING_FILE_NAME,
-                            Context.MODE_APPEND,
-                            refreshSuccessfulContent.toByteArray()
-                        )
-                    }
-                    .onFailure { throwable ->
-                        val errorMessage = if (throwable is BannerModel) {
-                            "${throwable.title}: ${throwable.description}"
-                        } else {
-                            throwable.message ?: throwable::class.simpleName ?: "UnknownError"
-                        }
-
-                        storageProvider.storeContent(
-                            ANDROID_NETWORKING_FILE_NAME,
-                            Context.MODE_APPEND,
-                            (
-                                TimeUtils.getLocalDateTime(Instant.now()).toString() +
-                                "\t Refreshed Token failure: " + errorMessage +
-                                "\t using the refresh token: " + accessTokenModel.refreshToken +
-                                "\n\n"
-                            ).toByteArray()
-                        )
-
-                        UnauthorizedEventHandler.publishUnauthorizedEvent(accessTokenModel.username)
-                    }
-            }
+        val refreshResult = resultOf { authRepository.refreshToken(accessTokenModel) }
+        val refreshedToken = refreshResult.getOrNull()
+        if (refreshedToken != null) {
+            logRefreshSuccess(accessTokenModel, refreshedToken)
+        } else {
+            handleRefreshFailure(accessTokenModel, refreshResult.exceptionOrNull())
         }
+    }
+
+    private fun logRefreshSuccess(
+        previousToken: AccessTokenModel,
+        refreshedToken: AccessTokenModel
+    ) {
+        val refreshSuccessfulContent =
+            TimeUtils.getLocalDateTime(Instant.now()).toString() +
+                "\t Refreshed Token model: " + refreshedToken +
+                "\t using the refresh token: " + previousToken.refreshToken +
+                "\t refreshed on: " + refreshedToken.refreshDateTime +
+                "\n\n"
+
+        storageProvider.storeContent(
+            ANDROID_NETWORKING_FILE_NAME,
+            Context.MODE_APPEND,
+            refreshSuccessfulContent.toByteArray()
+        )
+    }
+
+    private suspend fun handleRefreshFailure(
+        accessTokenModel: AccessTokenModel,
+        throwable: Throwable?
+    ) {
+        val errorMessage = when {
+            throwable is BannerModel -> "${throwable.title}: ${throwable.description}"
+            throwable != null ->
+                throwable.message ?: throwable::class.simpleName ?: "UnknownError"
+            else -> "UnknownError"
+        }
+
+        storageProvider.storeContent(
+            ANDROID_NETWORKING_FILE_NAME,
+            Context.MODE_APPEND,
+            (
+                TimeUtils.getLocalDateTime(Instant.now()).toString() +
+                    "\t Refreshed Token failure: " + errorMessage +
+                    "\t using the refresh token: " + accessTokenModel.refreshToken +
+                    "\n\n"
+                ).toByteArray()
+        )
+
+        // Remove the dead token from the cache so subsequent requests do not
+        // keep hitting Keycloak with an already-expired refresh token. Without
+        // this the next intercepted request (e.g. the periodic LocationWorker
+        // POST) finds the same expired entry, retries the refresh, fails again,
+        // and emits another UnauthorizedSession event — re-navigating the user
+        // back to the login screen mid-typing.
+        authRepository.deleteAccessTokenByUsername(accessTokenModel.username)
+        UnauthorizedEventHandler.publishUnauthorizedEvent(accessTokenModel.username)
     }
 }

--- a/app/src/test/java/com/skgtecnologia/sisem/data/remote/interceptors/AccessTokenAuthenticatorTest.kt
+++ b/app/src/test/java/com/skgtecnologia/sisem/data/remote/interceptors/AccessTokenAuthenticatorTest.kt
@@ -123,15 +123,16 @@ class AccessTokenAuthenticatorTest {
     }
 
     @Test
-    fun `when 401 and refresh fails, publishes unauthorized event and returns null without deleting token`() = runTest {
+    fun `when 401 and refresh fails, deletes dead token and publishes unauthorized event`() = runTest {
         val response = build401Response(totalAttemptCount = 1)
         coEvery { authRepository.observeCurrentAccessToken() } returns flowOf(expiredToken)
         coEvery { authRepository.refreshToken(expiredToken) } throws RuntimeException("refresh failed")
+        coEvery { authRepository.deleteAccessTokenByUsername("testuser") } just runs
 
         val result = authenticator.authenticate(null, response)
 
         assertNull(result)
-        coVerify(exactly = 0) { authRepository.deleteAccessTokenByUsername(any()) }
+        coVerify(exactly = 1) { authRepository.deleteAccessTokenByUsername("testuser") }
         verify(exactly = 1) { UnauthorizedEventHandler.publishUnauthorizedEvent("testuser") }
     }
 

--- a/app/src/test/java/com/skgtecnologia/sisem/data/remote/interceptors/AccessTokenInterceptorTest.kt
+++ b/app/src/test/java/com/skgtecnologia/sisem/data/remote/interceptors/AccessTokenInterceptorTest.kt
@@ -100,7 +100,7 @@ class AccessTokenInterceptorTest {
     }
 
     @Test
-    fun `when token expired and refresh fails with BannerModel, publishes event without deleting token`() = runTest {
+    fun `when token expired and refresh fails with BannerModel, deletes dead token and publishes event`() = runTest {
         val bannerError = BannerModel(
             icon = "ic_alert",
             title = "Token expired",
@@ -108,6 +108,7 @@ class AccessTokenInterceptorTest {
         )
         coEvery { authRepository.getAllAccessTokens() } returns listOf(expiredToken)
         coEvery { authRepository.refreshToken(expiredToken) } throws bannerError
+        coEvery { authRepository.deleteAccessTokenByUsername("testuser") } just runs
         coEvery { authRepository.getLastToken() } returns expiredToken.accessToken
         every { UnauthorizedEventHandler.publishUnauthorizedEvent("testuser") } just runs
 
@@ -123,20 +124,21 @@ class AccessTokenInterceptorTest {
                 }
             )
         }
-        coVerify(exactly = 0) { authRepository.deleteAccessTokenByUsername(any()) }
+        coVerify(exactly = 1) { authRepository.deleteAccessTokenByUsername("testuser") }
         verify(exactly = 1) { UnauthorizedEventHandler.publishUnauthorizedEvent("testuser") }
     }
 
     @Test
-    fun `when token expired and refresh fails with exception, publishes event without deleting`() = runTest {
+    fun `when token expired and refresh fails with exception, deletes dead token and publishes event`() = runTest {
         coEvery { authRepository.getAllAccessTokens() } returns listOf(expiredToken)
         coEvery { authRepository.refreshToken(expiredToken) } throws RuntimeException("network error")
+        coEvery { authRepository.deleteAccessTokenByUsername("testuser") } just runs
         coEvery { authRepository.getLastToken() } returns expiredToken.accessToken
         every { UnauthorizedEventHandler.publishUnauthorizedEvent("testuser") } just runs
 
         interceptor.intercept(chain)
 
-        coVerify(exactly = 0) { authRepository.deleteAccessTokenByUsername(any()) }
+        coVerify(exactly = 1) { authRepository.deleteAccessTokenByUsername("testuser") }
         verify(exactly = 1) { UnauthorizedEventHandler.publishUnauthorizedEvent("testuser") }
     }
 


### PR DESCRIPTION
## Summary

Cierra el loop de reautenticación que dejaba al usuario sin poder escribir las credenciales cuando el refresh token también expiraba.

**Reportado por Alejo Acevedo Espitia** sobre `v2.4.1 (84)` en Android 12:
> "Cuando los token se han vencido, se redirige al login, pero en esta vista se está haciendo múltiples llamados al `/token` y se queda en un ciclo donde no deja escribir las credenciales."

## Root cause

El flujo de re-auth tenía dos puntos de entrada (`AccessTokenInterceptor.handleTokenExpirationTime` por expiración de tiempo y `AccessTokenAuthenticator.createSignedRequest` por 401). En ambos, cuando `authRepository.refreshToken(...)` fallaba (Keycloak 400 porque el refresh token también estaba expirado), publicábamos `UnauthorizedSession` pero **dejábamos el token muerto en Room**.

Como `LocationWorker` dispara un POST cada ~5 s a través del cliente `@BearerAuthentication`, la siguiente request encontraba el mismo token expirado, reintentaba el refresh, volvía a fallar, y re-emitía el evento — re-navegando a `LoginRoute` y reiniciando `LoginViewModel` (con su `getLoginScreen.invoke(...)` y su spinner `isLoading = true`) mid-typing.

## Fix

En ambos paths, borrar el `AccessTokenModel` por `username` **antes** de publicar el evento de sesión inválida:

- `AccessTokenInterceptor.handleTokenExpirationTime` → `authRepository.deleteAccessTokenByUsername(accessTokenModel.username)` dentro de `handleRefreshFailure(...)`.
- `AccessTokenAuthenticator.createSignedRequest` → `runBlocking { authRepository.deleteAccessTokenByUsername(currentToken.username) }` dentro del bloque `synchronized(this) { ... }` (envuelto en `runBlocking` porque `synchronized` no es suspend).

Una vez borrado el token, las requests posteriores caen en la rama "sin token" y dejan de re-dispararnos a login.

## Refactor incidental

`handleTokenExpirationTime` quedaba con `NestedBlockDepth` por encima del umbral de detekt tras el cambio. La aplaté en helpers privados:

- `refreshExpiredToken(accessTokenModel)`
- `logRefreshSuccess(previousToken, refreshedToken)`
- `handleRefreshFailure(accessTokenModel, throwable)`

Sin cambio de comportamiento, solo separación de responsabilidades.

## Tests

3 tests existentes asercionaban explícitamente el comportamiento previo ("*without deleting token*"). Actualizados para verificar el comportamiento correcto:

- `AccessTokenAuthenticatorTest`: `when 401 and refresh fails, deletes dead token and publishes unauthorized event` → `coVerify(exactly = 1) { authRepository.deleteAccessTokenByUsername("testuser") }`.
- `AccessTokenInterceptorTest`: ambos casos de fallo (BannerModel y excepción genérica) ahora verifican el delete.

Local: `compileDebugKotlin` + `ktlintCheck` + `detekt` + 347 unit tests ✅.

## Test plan

- [ ] CI green.
- [ ] Smoke test en device:
  - [ ] Hacer login normal con `staging`/`debug`. Cerrar app, esperar que expire el access+refresh (o forzar `expDate < now` en DB) y reabrir → debe ir a login, el spinner debe limpiarse, **debe permitir escribir credenciales sin re-navegar**.
  - [ ] Confirmar que el log `ANDROID_NETWORKING_FILE_NAME` muestra `Refreshed Token failure: ...` una sola vez en lugar de cada ~5 s.
  - [ ] Re-loguear y validar que la sesión nueva funciona normalmente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
