### PR TITLE
fix: send refresh_token header on logout

### DIFF
--- a/app/src/main/java/com/skgtecnologia/sisem/data/auth/AuthRepositoryImpl.kt
+++ b/app/src/main/java/com/skgtecnologia/sisem/data/auth/AuthRepositoryImpl.kt
@@ -92,7 +92,10 @@ class AuthRepositoryImpl @Inject constructor(
         authCacheDataSource.retrieveAccessTokenByRole(role)
 
     override suspend fun logout(username: String): String =
-        authRemoteDataSource.logout(username)
+        authRemoteDataSource.logout(
+            username = username,
+            refreshToken = authCacheDataSource.retrieveAccessTokenByUsername(username).refreshToken
+        )
             .onSuccess {
                 authCacheDataSource.deleteAccessTokenByUsername(username = username)
                 authCacheDataSource.observeAccessToken().first()?.let { accessToken ->
@@ -107,9 +110,12 @@ class AuthRepositoryImpl @Inject constructor(
             }.getOrThrow()
 
     override suspend fun logoutCurrentUser(): String {
-        val username = authCacheDataSource.observeAccessToken().first()?.username.orEmpty()
+        val currentToken = authCacheDataSource.observeAccessToken().first()
 
-        return authRemoteDataSource.logout(username)
+        return authRemoteDataSource.logout(
+            username = currentToken?.username.orEmpty(),
+            refreshToken = currentToken?.refreshToken.orEmpty()
+        )
             .onSuccess {
                 authCacheDataSource.observeAccessToken().first()?.let { accessToken ->
                     authCacheDataSource.storeAccessToken(

--- a/app/src/main/java/com/skgtecnologia/sisem/data/auth/remote/AuthApi.kt
+++ b/app/src/main/java/com/skgtecnologia/sisem/data/auth/remote/AuthApi.kt
@@ -35,6 +35,7 @@ interface AuthApi {
 
     @GET("auth/logout")
     suspend fun logout(
-        @Header("username") username: String
+        @Header("username") username: String,
+        @Header("refresh_token") refreshToken: String
     ): Response<LogoutResponse>
 }

--- a/app/src/main/java/com/skgtecnologia/sisem/data/auth/remote/AuthRemoteDataSource.kt
+++ b/app/src/main/java/com/skgtecnologia/sisem/data/auth/remote/AuthRemoteDataSource.kt
@@ -37,9 +37,10 @@ class AuthRemoteDataSource @Inject constructor(
         it.mapToDomain()
     }
 
-    suspend fun logout(username: String): Result<String> = networkApi.apiCall {
-        authApi.logout(username = username)
-    }.mapResult {
-        username
-    }
+    suspend fun logout(username: String, refreshToken: String): Result<String> =
+        networkApi.apiCall {
+            authApi.logout(username = username, refreshToken = refreshToken)
+        }.mapResult {
+            username
+        }
 }


### PR DESCRIPTION
## Description

The backend now invalidates the refresh token on logout (change by @JarrisonGarcia's backend update) and requires it as an extra header on `GET auth/logout`:

```
curl -X GET 'https://api.emergencias.saludcapital.gov.co/sisem-api/auth/logout' \
  -H 'username: USER' \
  -H 'refresh_token: REFRESH_TOKEN'
```

This PR sends that header from the app:

- `AuthApi.logout` now takes a `refresh_token` header alongside `username`.
- `AuthRemoteDataSource.logout` propagates the token.
- `AuthRepositoryImpl`:
  - `logout(username)` reads the refresh token for that user from the Room cache (`retrieveAccessTokenByUsername`) — covers the admin bulk-logout loop in `authenticate`.
  - `logoutCurrentUser()` takes it from the active session token.

No changes needed in domain interfaces, use cases, ViewModels, or tests (they mock `AuthRepository`, whose signature is unchanged).

## Verification

- `ktlintCheck` ✅
- `detekt` ✅
- `testDebugUnitTest` ✅ (BUILD SUCCESSFUL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)