### PR TITLE
docs: note why held-back dependency versions are pinned

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,10 @@
 [versions]
 accompanist = "0.37.3"
-accompanist-placeholder = "0.36.0"
+accompanist-placeholder = "0.36.0" # held back: artifact discontinued after 0.36
 activity-compose = "1.13.0"
+# When AGP 9.1 goes stable: bump it here, raise compileSdk 36 -> 37 in both
+# modules, un-hold the versions marked "held back" below, and retry
+# Gradle 9.6+ (9.6.1 breaks AGP 9.0's unit-test reporting).
 agp = "9.0.0"
 androidx-test-ext-junit = "1.3.0"
 ben-manes-versions = "0.54.0"
@@ -14,7 +17,7 @@ compressor = "3.0.1"
 constraintlayout = "2.2.1"
 constraintlayout-compose = "1.1.1"
 converter-moshi = "3.0.0"
-core-ktx = "1.18.0"
+core-ktx = "1.18.0" # held back: 1.19+ requires compileSdk 37 / AGP 9.1
 core-splashscreen = "1.2.0"
 core-testing = "2.2.0"
 desugar-jdk-libs = "2.1.5"
@@ -25,7 +28,7 @@ fragment-compose = "1.8.9"
 google-material = "1.13.0"
 google-services = "4.4.4"
 hilt-android = "2.60.1"
-hilt-navigation-compose = "1.3.0"
+hilt-navigation-compose = "1.3.0" # held back: 1.4+ requires compileSdk 37 / AGP 9.1
 junit = "4.13.2"
 kotlin = "2.4.0"
 kotlinx-collections-immutable = "0.5.1"
@@ -34,7 +37,7 @@ kotlin-serialization = "1.11.0"
 ksp = "2.3.10"
 ktlint = "14.2.0"
 leakcanary-android = "2.14"
-lifecycle = "2.10.0"
+lifecycle = "2.10.0" # held back: 2.11+ requires compileSdk 37 / AGP 9.1
 mapbox-navigation = "3.4.0-beta.1"
 mockk = "1.14.11"
 moshi = "1.15.2"
@@ -48,7 +51,7 @@ room = "2.8.4"
 timber = "5.0.1"
 ui-viewbinding = "1.10.6"
 work-runtime-ktx = "2.11.2"
-hilt-work = "1.2.0"
+hilt-work = "1.2.0" # held back: 1.4+ requires compileSdk 37 / AGP 9.1
 
 [libraries]
 accompanist-permissions = { module = "com.google.accompanist:accompanist-permissions", version.ref = "accompanist" }


### PR DESCRIPTION
## Description

Adds comments in `gradle/libs.versions.toml` documenting why some versions from the outdated-dependencies report cannot be taken yet, so nobody bumps them blindly and hits the build breakage from #286's investigation:

- `core-ktx`, `hilt-navigation-compose`, `hilt-work`, `lifecycle` — their next versions require compileSdk 37 / AGP 9.1 (not yet stable).
- `accompanist-placeholder` — artifact discontinued after 0.36.
- Note on `agp` describing the unlock chain (AGP 9.1 → compileSdk 37 → un-hold the pins → Gradle 9.6+).

Comment-only change; no version moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)