### PR TITLE
fix: invalidate Keycloak session on crew member logout

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -39,8 +39,8 @@ android {
         applicationId = "com.skgtecnologia.sisem"
         minSdk = 30
         targetSdk = 36
-        versionCode = 86
-        versionName = "2.4.3"
+        versionCode = 87
+        versionName = "2.4.4"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/skgtecnologia/sisem/data/operation/OperationRepositoryImpl.kt
+++ b/app/src/main/java/com/skgtecnologia/sisem/data/operation/OperationRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.skgtecnologia.sisem.data.operation
 
 import com.skgtecnologia.sisem.commons.extensions.mapResult
 import com.skgtecnologia.sisem.data.auth.cache.AuthCacheDataSource
+import com.skgtecnologia.sisem.data.auth.remote.AuthRemoteDataSource
 import com.skgtecnologia.sisem.data.operation.cache.OperationCacheDataSource
 import com.skgtecnologia.sisem.data.operation.remote.OperationRemoteDataSource
 import com.skgtecnologia.sisem.domain.authcards.model.OperationModel
@@ -12,6 +13,7 @@ import javax.inject.Inject
 
 class OperationRepositoryImpl @Inject constructor(
     private val authCacheDataSource: AuthCacheDataSource,
+    private val authRemoteDataSource: AuthRemoteDataSource,
     private val operationCacheDataSource: OperationCacheDataSource,
     private val operationRemoteDataSource: OperationRemoteDataSource
 ) : OperationRepository {
@@ -29,15 +31,23 @@ class OperationRepositoryImpl @Inject constructor(
     override suspend fun logoutTurn(username: String): String {
         val previousTurnId = authCacheDataSource.observeAccessToken()
             .first()?.turn?.id?.toString().orEmpty()
-        val idEmployed = authCacheDataSource.retrieveAccessTokenByUsername(username)
-            .userId.toString()
+        val accessToken = authCacheDataSource.retrieveAccessTokenByUsername(username)
         val code = operationCacheDataSource.observeOperationConfig().first()?.vehicleCode.orEmpty()
 
         return operationRemoteDataSource.logoutTurn(
             idTurn = previousTurnId,
-            idEmployed = idEmployed,
+            idEmployed = accessToken.userId.toString(),
             vehicleCode = code
-        ).onSuccess {
+        ).mapResult { turnId ->
+            // Closing the turn does not invalidate the Keycloak session; without
+            // this call the crew member cannot authenticate again (SMA-753).
+            authRemoteDataSource.logout(
+                username = username,
+                refreshToken = accessToken.refreshToken
+            ).getOrThrow()
+
+            turnId
+        }.onSuccess {
             authCacheDataSource.deleteAccessTokenByUsername(username = username)
             authCacheDataSource.observeAccessToken().first()?.let { accessToken ->
                 authCacheDataSource.storeAccessToken(

--- a/app/src/test/java/com/skgtecnologia/sisem/data/operation/OperationRepositoryImplTest.kt
+++ b/app/src/test/java/com/skgtecnologia/sisem/data/operation/OperationRepositoryImplTest.kt
@@ -1,0 +1,109 @@
+package com.skgtecnologia.sisem.data.operation
+
+import com.skgtecnologia.sisem.commons.MainDispatcherRule
+import com.skgtecnologia.sisem.data.auth.cache.AuthCacheDataSource
+import com.skgtecnologia.sisem.data.auth.remote.AuthRemoteDataSource
+import com.skgtecnologia.sisem.data.operation.cache.OperationCacheDataSource
+import com.skgtecnologia.sisem.data.operation.remote.OperationRemoteDataSource
+import com.skgtecnologia.sisem.domain.auth.model.AccessTokenModel
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+private const val USERNAME = "crew_member"
+private const val REFRESH_TOKEN = "refresh_token_value"
+private const val TURN_ID = "42"
+
+class OperationRepositoryImplTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @MockK private lateinit var authCacheDataSource: AuthCacheDataSource
+
+    @MockK private lateinit var authRemoteDataSource: AuthRemoteDataSource
+
+    @MockK private lateinit var operationCacheDataSource: OperationCacheDataSource
+
+    @MockK private lateinit var operationRemoteDataSource: OperationRemoteDataSource
+
+    private lateinit var repository: OperationRepositoryImpl
+
+    private val accessToken = mockk<AccessTokenModel>(relaxed = true) {
+        every { username } returns USERNAME
+        every { userId } returns 7
+        every { refreshToken } returns REFRESH_TOKEN
+    }
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this, relaxed = true)
+        repository = OperationRepositoryImpl(
+            authCacheDataSource,
+            authRemoteDataSource,
+            operationCacheDataSource,
+            operationRemoteDataSource
+        )
+
+        coEvery { authCacheDataSource.observeAccessToken() } returns flowOf(accessToken)
+        coEvery {
+            authCacheDataSource.retrieveAccessTokenByUsername(USERNAME)
+        } returns accessToken
+        coEvery { operationCacheDataSource.observeOperationConfig() } returns flowOf(null)
+        coEvery {
+            operationRemoteDataSource.logoutTurn(any(), any(), any())
+        } returns Result.success(TURN_ID)
+    }
+
+    @Test
+    fun `logoutTurn invalidates the session with the crew member refresh token`() = runTest {
+        coEvery {
+            authRemoteDataSource.logout(username = USERNAME, refreshToken = REFRESH_TOKEN)
+        } returns Result.success(USERNAME)
+
+        val result = repository.logoutTurn(USERNAME)
+
+        assertEquals(TURN_ID, result)
+        coVerify(exactly = 1) {
+            authRemoteDataSource.logout(username = USERNAME, refreshToken = REFRESH_TOKEN)
+        }
+        coVerify(exactly = 1) {
+            authCacheDataSource.deleteAccessTokenByUsername(username = USERNAME)
+        }
+    }
+
+    @Test
+    fun `logoutTurn keeps the cached token when the session logout fails`() = runTest {
+        coEvery {
+            authRemoteDataSource.logout(username = USERNAME, refreshToken = REFRESH_TOKEN)
+        } returns Result.failure(IllegalStateException("logout failed"))
+
+        val result = runCatching { repository.logoutTurn(USERNAME) }
+
+        assertEquals(true, result.isFailure)
+        coVerify(exactly = 0) {
+            authCacheDataSource.deleteAccessTokenByUsername(username = any())
+        }
+    }
+
+    @Test
+    fun `logoutTurn does not invalidate the session when closing the turn fails`() = runTest {
+        coEvery {
+            operationRemoteDataSource.logoutTurn(any(), any(), any())
+        } returns Result.failure(IllegalStateException("turn close failed"))
+
+        val result = runCatching { repository.logoutTurn(USERNAME) }
+
+        assertEquals(true, result.isFailure)
+        coVerify(exactly = 0) { authRemoteDataSource.logout(any(), any()) }
+    }
+}


### PR DESCRIPTION
## Description

Fixes the remaining half of [SMA-753](https://skgtecnologia.atlassian.net/browse/SMA-753): after the NGINX ingress fix, logout works for the APH leader but **crew members (driver, medic, auxiliary APH) still cannot re-authenticate after logging out** — Keycloak keeps their session alive.

### Root cause

The app has two logout paths, dispatched by role in `MenuDrawer`:

- **Leader/admin** → `Logout` use case → `GET auth/logout` with the `refresh_token` header → Keycloak session invalidated ✅
- **Crew members** → `LogoutTurn` use case → only closed the turn on the operations service and deleted the cached token. It **never called `auth/logout`**, so the Keycloak session survived ❌

### Fix

`OperationRepositoryImpl.logoutTurn` now calls `auth/logout` with the crew member's own refresh token after the turn closes, and only deletes the cached token when both remote calls succeed — a failed invalidation keeps the token so the user can retry instead of being left with an orphaned Keycloak session.

Also bumps the version to **2.4.4 (87)** for QA revalidation.

## Testing

- New `OperationRepositoryImplTest` covering: session invalidated with the crew member's refresh token on success; cached token kept when the auth logout fails; auth logout skipped when the turn close fails.
- `ktlintCheck`, `detekt`, `testDebugUnitTest` all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)