### PR TITLE
fix: rebind map observers to the view lifecycle

### DIFF
--- a/app/src/main/java/com/skgtecnologia/sisem/ui/map/MapFragment.kt
+++ b/app/src/main/java/com/skgtecnologia/sisem/ui/map/MapFragment.kt
@@ -71,12 +71,10 @@ import com.skgtecnologia.sisem.R
 import com.skgtecnologia.sisem.commons.extensions.biLet
 import com.skgtecnologia.sisem.databinding.FragmentMapBinding
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import kotlin.time.Duration.Companion.minutes
 
-private const val ACTIVE_INCIDENT_OBSERVATION_DELAY = 3000L
 private const val PADDING_TOP_SMALL = 140.0
 private const val PADDING_TOP_LARGE = 180.0
 private const val PADDING_HORIZONTAL = 40.0
@@ -88,7 +86,11 @@ private const val PADDING_BOTTOM_LARGE = 150.0
 @AndroidEntryPoint
 class MapFragment : Fragment(R.layout.fragment_map) {
 
-    private lateinit var binding: FragmentMapBinding
+    // Only valid between onCreateView and onDestroyView. Callbacks that can outlive
+    // the view must read [mapBinding] defensively instead of assuming it.
+    private var mapBinding: FragmentMapBinding? = null
+    private val binding
+        get() = requireNotNull(mapBinding) { "Accessed binding outside the view lifecycle" }
     val viewModel: MapFragmentViewModel by viewModels()
 
     private var destinationLocation: Location? = null
@@ -102,7 +104,7 @@ class MapFragment : Fragment(R.layout.fragment_map) {
 
     private val onPositionChangedListener = OnIndicatorPositionChangedListener { point ->
         val result = routeLineApi.updateTraveledRouteLine(point)
-        binding.mapView.mapboxMap.style?.apply {
+        mapBinding?.mapView?.mapboxMap?.style?.apply {
             routeLineView.renderRouteLineUpdate(this, result)
         }
     }
@@ -128,9 +130,11 @@ class MapFragment : Fragment(R.layout.fragment_map) {
             .build()
     }
 
-    private val routeCalloutView by lazy {
-        MapboxRouteCalloutView(binding.mapView, routeCalloutViewOptions)
-    }
+    // Bound to the MapView, so it must be rebuilt whenever the view is recreated —
+    // a lazy here would keep rendering into the destroyed MapView.
+    private var routeCalloutView: MapboxRouteCalloutView? = null
+
+    private var isNavigationInitializedForView = false
 
     private val routeLineApiOptions: MapboxRouteLineApiOptions by lazy {
         MapboxRouteLineApiOptions.Builder()
@@ -203,7 +207,7 @@ class MapFragment : Fragment(R.layout.fragment_map) {
                 newRoutes = routesResult.navigationRoutes,
                 alternativeRoutesMetadata = metadata,
             ).apply {
-                routeCalloutView.renderCallouts(this)
+                routeCalloutView?.renderCallouts(this)
             }
 
             // update the camera position to account for the new route
@@ -307,14 +311,29 @@ class MapFragment : Fragment(R.layout.fragment_map) {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        binding = FragmentMapBinding.inflate(inflater, container, false)
+        mapBinding = FragmentMapBinding.inflate(inflater, container, false)
 
         return binding.root
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+
+        // Everything below is tied to the MapView being destroyed. Without this the
+        // observers kept rendering into a detached map when the app came back from
+        // the background, leaving the map frozen and the incident invisible (SMA-755).
+        mapBinding?.mapView?.location?.removeOnIndicatorPositionChangedListener(
+            onPositionChangedListener
+        )
+        routeCalloutView = null
+        isNavigationInitializedForView = false
+        mapBinding = null
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        routeCalloutView = MapboxRouteCalloutView(binding.mapView, routeCalloutViewOptions)
         viewportDataSource = MapboxNavigationViewportDataSource(binding.mapView.mapboxMap)
         navigationCamera = NavigationCamera(
             binding.mapView.mapboxMap,
@@ -376,6 +395,8 @@ class MapFragment : Fragment(R.layout.fragment_map) {
 
         initViewInteractions()
         initObservers()
+        // No-op when Mapbox already initialized navigation for this view.
+        initNavigation()
     }
 
     private fun initViewInteractions() {
@@ -402,8 +423,9 @@ class MapFragment : Fragment(R.layout.fragment_map) {
     }
 
     private fun initObservers() {
-        lifecycleScope.launch {
-            delay(ACTIVE_INCIDENT_OBSERVATION_DELAY)
+        // viewLifecycleOwner, not the fragment: onViewCreated runs again every time the
+        // view is recreated, and a fragment-scoped collector would survive and stack up.
+        viewLifecycleOwner.lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.uiState.collect { mapFragmentUiState ->
                     val incident = mapFragmentUiState.incident
@@ -421,10 +443,17 @@ class MapFragment : Fragment(R.layout.fragment_map) {
         }
     }
 
+    /**
+     * Invoked both by Mapbox's `onInitialize` callback and by [onViewCreated], since the
+     * SDK can initialize before the view exists. Guarded so the puck is wired exactly
+     * once per view, on whichever of the two happens last.
+     */
     private fun initNavigation() {
         Timber.d("initNavigation")
-        lifecycleScope.launch {
-            delay(ACTIVE_INCIDENT_OBSERVATION_DELAY)
+        if (view == null || isNavigationInitializedForView) return
+        isNavigationInitializedForView = true
+
+        viewLifecycleOwner.lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 // initialize location puck
                 binding.mapView.location.apply {


### PR DESCRIPTION
## Description

Addresses point 1 of [SMA-755](https://skgtecnologia.atlassian.net/browse/SMA-755): *"al regresar a SISEM el incidente ya no se visualiza y el mapa parece quedar en un segundo plano"*.

### Root cause

`MapFragment` collected the active incident on the **fragment's** `lifecycleScope` rather than the **view's**. `onViewCreated` runs again every time Android recreates the view after the app has been in the background, so each round trip launched another collector while the previous ones stayed alive. Compounding it, the fragment had **no `onDestroyView` at all** and never released its binding, so those leaked collectors kept rendering into the detached `MapView` — a map that is present but inert, with no incident drawn.

### Changes

- Observe on `viewLifecycleOwner.lifecycleScope`, so collectors are cancelled with the view instead of stacking up.
- Add `onDestroyView`: release the binding, remove the indicator-position listener, and drop the `MapView`-bound route callout view.
- Rebuild `routeCalloutView` per view — as a `by lazy` it captured the first `MapView` and held it forever.
- Remove the arbitrary `delay(3000)` in front of both `repeatOnLifecycle` blocks, which left the incident invisible for three seconds on every return from background.
- Guard `initNavigation` so the location puck is wired exactly once per view, whether Mapbox's `onInitialize` or `onViewCreated` runs last.

The binding accessors that can outlive the view (`onPositionChangedListener`, `routeCalloutView`) were made null-safe, so the stricter binding access cannot turn the old silent misbehaviour into a crash.

## Testing

`ktlintCheck`, `detekt`, `compileStagingKotlin` and `testDebugUnitTest` pass.

**No automated test covers this fix, and none is added.** The repo has no fragment or instrumentation test infrastructure (Robolectric is used for ViewModels only), and `MapFragment` inflates a Mapbox `MapView` that needs native libraries and a token, so it cannot be driven in a JVM test. A test that passed without exercising that would be verifying a test double, not the fix.

Verification still pending on a device: reproduce the background → return cycle with an active incident. This is currently blocked because the QA backend rejects both the emulator's own serial and the one documented in `testing.md` with HTTP 500 (`GET /qa/sisem-api/v1/config?serial=…`), so login is unreachable — we need a device serial registered to a vehicle in QA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)