### PR TITLE
chore: allow screenshots and a pinned serial on test builds

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,6 +18,11 @@ plugins {
 val keystorePropertiesFile = rootProject.file("keystore.properties")
 val keystorePropertiesExist = keystorePropertiesFile.exists()
 
+// Pairs a debug/staging build with a vehicle already registered in the backend, so QA
+// scenarios can be reproduced without rewriting the cached android_id by hand. Set it in
+// ~/.gradle/gradle.properties or pass -PsisemTestSerial=<serial>; never commit a value.
+val testDeviceSerial: String = providers.gradleProperty("sisemTestSerial").getOrElse("")
+
 android {
     signingConfigs {
         if (keystorePropertiesExist) {
@@ -47,6 +52,11 @@ android {
             useSupportLibrary = true
         }
 
+        // Secure by default: screenshots blocked and no device-serial override.
+        // Only the debug and staging build types opt out, below.
+        buildConfigField("Boolean", "ALLOW_SCREENSHOTS", "false")
+        buildConfigField("String", "TEST_DEVICE_SERIAL", "\"\"")
+
         room {
             schemaDirectory("$projectDir/schemas")
         }
@@ -64,6 +74,8 @@ android {
             buildConfigField("String", "BASE_URL", "\"https://test.sisem.co/dev/sisem-api/v1/\"")
             buildConfigField("String", "LOCATION_URL", "\"https://test.sisem.co/dev/sisem-location-api/v1/\"")
             buildConfigField("String", "REFRESH_URL", "\"https://admin.qa.sisem.co/auth/realms/sisem/protocol/openid-connect/token\"")
+            buildConfigField("Boolean", "ALLOW_SCREENSHOTS", "true")
+            buildConfigField("String", "TEST_DEVICE_SERIAL", "\"$testDeviceSerial\"")
         }
         create("staging") {
             initWith(getByName("debug"))
@@ -81,6 +93,10 @@ android {
             buildConfigField("String", "BASE_URL", "\"https://mobile-preprod.sisem.co/sisem-api/v1/\"")
             buildConfigField("String", "LOCATION_URL", "\"https://mobile-preprod.sisem.co/sisem-location-api/v1/\"")
             buildConfigField("String", "REFRESH_URL", "\"https://admin-preprod.sisem.co/auth/realms/sisem/protocol/openid-connect/token\"")
+            // initWith(debug) copies the test-only opt-outs, but preProd runs against
+            // pre-production data — undo them.
+            buildConfigField("Boolean", "ALLOW_SCREENSHOTS", "false")
+            buildConfigField("String", "TEST_DEVICE_SERIAL", "\"\"")
         }
         release {
             isDebuggable = true

--- a/app/src/main/java/com/skgtecnologia/sisem/commons/resources/AndroidIdProviderImpl.kt
+++ b/app/src/main/java/com/skgtecnologia/sisem/commons/resources/AndroidIdProviderImpl.kt
@@ -3,6 +3,7 @@ package com.skgtecnologia.sisem.commons.resources
 import android.annotation.SuppressLint
 import android.content.Context
 import android.provider.Settings
+import com.skgtecnologia.sisem.BuildConfig
 import dagger.hilt.android.qualifiers.ApplicationContext
 import java.io.File
 import javax.inject.Inject
@@ -22,9 +23,17 @@ class AndroidIdProviderImpl @Inject constructor(
     override fun getAndroidId(): String {
         cachedAndroidId?.let { return it }
         return synchronized(this) {
-            cachedAndroidId ?: readOrInitializeAndroidId().also { cachedAndroidId = it }
+            cachedAndroidId ?: resolveAndroidId().also { cachedAndroidId = it }
         }
     }
+
+    /**
+     * Debug and staging builds may be pinned to a serial already registered against a
+     * vehicle in the backend (see `sisemTestSerial`). The field is empty everywhere else,
+     * so preProd and release always fall through to the real device id.
+     */
+    private fun resolveAndroidId(): String =
+        BuildConfig.TEST_DEVICE_SERIAL.ifEmpty { readOrInitializeAndroidId() }
 
     @SuppressLint("HardwareIds")
     private fun readOrInitializeAndroidId(): String {

--- a/app/src/main/java/com/skgtecnologia/sisem/ui/MainActivity.kt
+++ b/app/src/main/java/com/skgtecnologia/sisem/ui/MainActivity.kt
@@ -55,8 +55,9 @@ class MainActivity : FragmentActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
 
-        // Prevent Screenshots on all build types but debug
-        if (BuildConfig.BUILD_TYPE != "debug") {
+        // Block screenshots wherever real patient data can appear. Debug and staging opt
+        // out so QA can capture evidence against the test backend.
+        if (!BuildConfig.ALLOW_SCREENSHOTS) {
             window.setFlags(
                 WindowManager.LayoutParams.FLAG_SECURE,
                 WindowManager.LayoutParams.FLAG_SECURE


### PR DESCRIPTION
## Description

Two test-only opt-outs that QA and the mobile team have been recreating by hand (and that were last seen living in a local stash, now lost):

1. **`FLAG_SECURE`** was applied to every build type except `debug`, so no screenshot or screen recording could be captured on **staging** — the variant QA actually reproduces against. Evidence for tickets had to be filmed with a second phone.
2. **Pairing a build with a vehicle registered in the backend** required force-stopping the app and overwriting the cached `android_id` with `run-as` after every install (see `documentation/testing.md`).

Both are now explicit `buildConfigField`s that **default to the secure value** and are only relaxed on `debug` and `staging`:

| Variant | `ALLOW_SCREENSHOTS` | `TEST_DEVICE_SERIAL` |
|---|---|---|
| debug | `true` | from `sisemTestSerial` |
| staging | `true` | from `sisemTestSerial` |
| preProd | `false` | `""` |
| release | `false` | `""` |

`preProd` sets both back explicitly: it is created with `initWith(getByName("debug"))`, so without that it silently inherited the opt-outs into a build that talks to pre-production data. This was caught by generating `BuildConfig` for all four variants — worth knowing for any future flag added to `debug`.

The serial is read from the **`sisemTestSerial` Gradle property**, so no serial is committed. Omitting it leaves an empty value and today's behaviour is unchanged.

Usage:

```bash
./gradlew assembleStaging -PsisemTestSerial=<serial-registered-in-qa>
```

or put `sisemTestSerial=<serial>` in `~/.gradle/gradle.properties`.

## Testing

- `BuildConfig` generated for all four variants, with and without the property — values match the table above; `release` and `preProd` keep `ALLOW_SCREENSHOTS=false` and an empty serial in both cases.
- `ktlintCheck`, `detekt` and `testDebugUnitTest` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)