### PR TITLE
fix: end the session when the token refresh fails

### DIFF
--- a/app/src/main/java/com/skgtecnologia/sisem/data/remote/interceptors/AccessTokenAuthenticator.kt
+++ b/app/src/main/java/com/skgtecnologia/sisem/data/remote/interceptors/AccessTokenAuthenticator.kt
@@ -135,11 +135,18 @@ class AccessTokenAuthenticator @Inject constructor(
                     ).toByteArray()
                 )
 
-                // Drop the dead token from the cache. If we keep it, the next
-                // 401-driven authenticate() call reads the same expired refresh
-                // token, fails again, and emits another UnauthorizedSession event
-                // — looping the user back to the login screen on every retry.
                 runBlocking {
+                    // End the session server-side before discarding the token. This path
+                    // sends the user to the login screen, and without the logout the
+                    // Keycloak session stays open — the next sign-in is then rejected as
+                    // invalid credentials. Failures are swallowed on purpose: the token is
+                    // already dead, so there is nothing left to retry with.
+                    runCatching { authRepository.logout(currentToken.username) }
+
+                    // Drop the dead token from the cache. If we keep it, the next
+                    // 401-driven authenticate() call reads the same expired refresh
+                    // token, fails again, and emits another UnauthorizedSession event
+                    // — looping the user back to the login screen on every retry.
                     authRepository.deleteAccessTokenByUsername(currentToken.username)
                 }
                 UnauthorizedEventHandler.publishUnauthorizedEvent(currentToken.username)

--- a/app/src/test/java/com/skgtecnologia/sisem/data/remote/interceptors/AccessTokenAuthenticatorTest.kt
+++ b/app/src/test/java/com/skgtecnologia/sisem/data/remote/interceptors/AccessTokenAuthenticatorTest.kt
@@ -7,6 +7,7 @@ import com.skgtecnologia.sisem.domain.auth.model.AccessTokenModel
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.coVerifyOrder
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.just
@@ -131,6 +132,39 @@ class AccessTokenAuthenticatorTest {
 
         val result = authenticator.authenticate(null, response)
 
+        assertNull(result)
+        coVerify(exactly = 1) { authRepository.deleteAccessTokenByUsername("testuser") }
+        verify(exactly = 1) { UnauthorizedEventHandler.publishUnauthorizedEvent("testuser") }
+    }
+
+    @Test
+    fun `when 401 and refresh fails, ends the session before dropping the token`() = runTest {
+        val response = build401Response(totalAttemptCount = 1)
+        coEvery { authRepository.observeCurrentAccessToken() } returns flowOf(expiredToken)
+        coEvery { authRepository.refreshToken(expiredToken) } throws RuntimeException("refresh failed")
+        coEvery { authRepository.logout("testuser") } returns "testuser"
+        coEvery { authRepository.deleteAccessTokenByUsername("testuser") } just runs
+
+        authenticator.authenticate(null, response)
+
+        coVerifyOrder {
+            authRepository.logout("testuser")
+            authRepository.deleteAccessTokenByUsername("testuser")
+        }
+    }
+
+    @Test
+    fun `when 401 and both refresh and logout fail, still drops the token and notifies`() = runTest {
+        val response = build401Response(totalAttemptCount = 1)
+        coEvery { authRepository.observeCurrentAccessToken() } returns flowOf(expiredToken)
+        coEvery { authRepository.refreshToken(expiredToken) } throws RuntimeException("refresh failed")
+        coEvery { authRepository.logout("testuser") } throws RuntimeException("logout failed")
+        coEvery { authRepository.deleteAccessTokenByUsername("testuser") } just runs
+
+        val result = authenticator.authenticate(null, response)
+
+        // A failed logout must not strand the user: the dead token still goes away and
+        // the app still routes to the login screen.
         assertNull(result)
         coVerify(exactly = 1) { authRepository.deleteAccessTokenByUsername("testuser") }
         verify(exactly = 1) { UnauthorizedEventHandler.publishUnauthorizedEvent("testuser") }


### PR DESCRIPTION
## Description

Reported from testing: *"cuando se cierra la sesión en la app… te envía al login, y luego si intentas hacer login responde credenciales no corresponden, como si la sesión siguiera abierta"*.

That is a different path from the two logout fixes already merged. Three places in the app end up on the login screen, and only two of them told the backend about it:

| Path | Invalidates the Keycloak session? |
|---|---|
| Leader/admin signs out → `Logout` | ✅ since #285 |
| Crew member signs out → `LogoutTurn` | ✅ since #288 |
| **Token refresh fails → automatic redirect** | ❌ **this PR** |

### Root cause

On a failed refresh, `AccessTokenAuthenticator` deleted the cached token and published `UnauthorizedSession` — which `SisemNavGraph` turns into a navigation to the login screen — but never called `auth/logout`. The session therefore stayed open in Keycloak, and because single-session control (RF0199) rejects a second login, the user was told their credentials were wrong. With the local token already deleted, there was nothing left in the app to recover with either.

The token deletion itself came from #284, which fixed a re-auth loop; it closed the loop but left the server-side session orphaned.

### Fix

Call `auth/logout` before discarding the token. The result is deliberately ignored — the refresh token is already dead, so there is nothing to retry — and the cached token is deleted either way, preserving the #284 behaviour.

## Testing

Two tests added to `AccessTokenAuthenticatorTest`:

- the session is ended **before** the token is dropped (`coVerifyOrder`);
- when the logout *also* fails, the token is still dropped and `UnauthorizedSession` is still published, so a failing logout can never strand the user on a dead session.

`ktlintCheck`, `detekt` and `testDebugUnitTest` pass.

Verification on a device is still worth doing by QA (log in, force a refresh failure, sign in again) — the emulator on the dev machine cannot run this app reliably.

🤖 Generated with [Claude Code](https://claude.com/claude-code)