### PR TITLE
docs: add CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# CHANGELOG
+Ajustes y correcciones aplicadas segun versiones:
+
+
+
+# version X.X.X *(DD.MM.YYYY)*
+----------------------------------------
+- Reemplazar por el contenido


### PR DESCRIPTION
## Description

Brings over the `CHANGELOG.md` template that @AlejandroAcevedoSkg added directly on the **GitLab mirror** (`dc8d9d26`, 2026-07-26), so the file also exists in GitHub.

The file is unchanged from what he wrote — it is still the empty template, to be filled in per release.

### Why

GitHub is the source of truth and GitLab is mirrored from it. A file that exists only on the mirror is fragile: the reconciliation merge used to sync the two repos takes the GitHub content, so it would have silently deleted this file on the next sync (it was caught by hand this time). Having it here removes the exception.

Worth agreeing as a team that the changelog is edited in GitHub, not on the mirror, for the same reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)