### PR TITLE
chore: bump version to 2.4.5 (88)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -44,8 +44,8 @@ android {
         applicationId = "com.skgtecnologia.sisem"
         minSdk = 30
         targetSdk = 36
-        versionCode = 87
-        versionName = "2.4.4"
+        versionCode = 88
+        versionName = "2.4.5"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {


### PR DESCRIPTION
## Description

Version bump `2.4.4 (87)` → `2.4.5 (88)` ahead of the build QA will revalidate.

QA already validated and signed off an APK labelled **2.4.4** (the crew logout fix, #288). Since then four commits landed on `main`:

- #289 — map observers rebound to the view lifecycle (SMA-755 pt. 1)
- #290 — screenshots and pinned serial on test builds
- #291 — session ended when the token refresh fails
- #292 — `CHANGELOG.md`

Shipping those under `2.4.4` would mean two different binaries with the same version, so there would be no way to tell which one a tester actually ran.

🤖 Generated with [Claude Code](https://claude.com/claude-code)