### PR TITLE
docs: document the 2.4.5 fixes in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Ajustes y correcciones aplicadas segun versiones:
 
 
 
-# version X.X.X *(DD.MM.YYYY)*
+# version 2.4.5 *(26.07.2026)*
 ----------------------------------------
-- Reemplazar por el contenido
+### Correcciones
+
+- **Inicio de sesión tras expiración de sesión:** Se corrige un problema donde, al expirar la sesión automáticamente, el usuario era redirigido al login pero al intentar ingresar de nuevo veía el mensaje *"credenciales incorrectas"*. Ahora la sesión se cierra correctamente en el servidor antes de redirigir al login, permitiendo iniciar sesión sin inconvenientes.
+
+- **Mapa congelado al volver a la aplicación:** Se corrige un problema donde, al regresar a SISEM desde segundo plano, el mapa de la incidencia activa aparecía congelado o en blanco. Ahora el mapa se recarga correctamente cada vez que se vuelve a la pantalla.


### PR DESCRIPTION
## Description

Brings over the 2.4.5 changelog entry @AlejandroAcevedoSkg wrote directly on the **GitLab mirror** (`3a759236`), covering the two fixes shipped in that build:

- login rejected after an automatic session expiry (#291)
- frozen/blank map when returning from background (#289)

Text unchanged from what he wrote.

### Why

Same reason as #292: GitHub is the source of truth and GitLab is mirrored from it, so a file edited only on the mirror gets overwritten by the next sync. Bringing it back keeps both repos identical.

Worth agreeing that the changelog is edited here rather than on the mirror — this is the second time an edit has had to be recovered from GitLab by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)