### PR TITLE
chore: warn when a PR skips the changelog

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -16,6 +16,21 @@ if git.deletions > git.insertions
     message  "🎉 Code Cleanup!"
 end
 
+# Remind to record user-facing changes in the changelog.
+#
+# Only shipped code counts: a PR that just moves tests, docs or build configuration has
+# nothing for a release note. The changelog lives here and is mirrored to GitLab, so it
+# has to be edited in this repository — edits made on the mirror are overwritten by the
+# next sync.
+touchedShippedCode = (git.modified_files + git.added_files).any? do |file|
+    file.start_with?("app/src/main/", "uicomponents/src/main/")
+end
+
+if touchedShippedCode && !(git.modified_files + git.added_files).include?("CHANGELOG.md")
+    warn "This PR changes shipped code but does not update CHANGELOG.md. " \
+         "Add an entry under the target version, or say in the description why it is not needed."
+end
+
 # Notify of outdated dependencies
 dependencyUpdatesHeader = "The following dependencies have later milestone versions:"
 dependencyReportsFile = "app/build/dependencyUpdates/report.txt"


### PR DESCRIPTION
## Description

`CHANGELOG.md` keeps being filled in after the fact, and twice now the entry was written directly on the **GitLab mirror** and had to be recovered by hand before the next sync overwrote it (#292, #294).

Danger now warns when a PR modifies `app/src/main/` or `uicomponents/src/main/` without also touching `CHANGELOG.md`, so the entry gets written by whoever made the change, while the change is still fresh.

### Why a warning and not a failure

Plenty of shipped-code changes are internal — refactors, dependency plumbing, logging — and have nothing to tell the people who operate the app. Failing those PRs would train everyone to add filler entries. A warning prompts the author to either add the entry or say in the description why it isn't needed.

Test-only, docs-only and build-config-only PRs are not flagged at all: the check looks solely at the two shipped source trees.

Note this PR itself does not update the changelog — it changes no shipped code, so the new rule does not fire on it.

## Testing

Danger runs on this PR; the new check is exercised against a diff that touches neither source tree (no warning expected).

Follow-up worth agreeing as a team: the changelog is edited in **GitHub**, not on the mirror.

🤖 Generated with [Claude Code](https://claude.com/claude-code)