### PR TITLE
fix: keep the forgot-password form usable with the keyboard open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Ajustes y correcciones aplicadas segun versiones:
 
 
 
+# version 2.4.6 *(27.07.2026)*
+----------------------------------------
+### Correcciones
+
+- **Recuperar contraseña en pantallas pequeñas:** Se corrige un problema donde, al abrir el teclado en la pantalla *"Olvidó su contraseña"*, desaparecían el campo de correo y los botones Cancelar y Enviar, dejando la pantalla inutilizable. Se presentaba en equipos donde el teclado ocupa una porción mayor de la pantalla, como el Motorola G47. Ahora el contenido y los botones permanecen visibles sobre el teclado.
+
 # version 2.4.5 *(26.07.2026)*
 ----------------------------------------
 ### Correcciones

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -44,8 +44,8 @@ android {
         applicationId = "com.skgtecnologia.sisem"
         minSdk = 30
         targetSdk = 36
-        versionCode = 88
-        versionName = "2.4.5"
+        versionCode = 89
+        versionName = "2.4.6"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/skgtecnologia/sisem/ui/forgotpassword/ForgotPasswordScreen.kt
+++ b/app/src/main/java/com/skgtecnologia/sisem/ui/forgotpassword/ForgotPasswordScreen.kt
@@ -1,6 +1,7 @@
 package com.skgtecnologia.sisem.ui.forgotpassword
 
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -43,7 +44,13 @@ fun ForgotPasswordScreen(
     }
 
     ConstraintLayout(
-        modifier = modifier.fillMaxSize()
+        // Inset the whole layout, not the list inside it: the body is pinned between the
+        // header and the footer, so padding applied inside it shrinks the visible area to
+        // nothing once the keyboard is tall enough (reported on a Motorola G47). Insetting
+        // here lifts the footer above the keyboard and leaves the body the rest.
+        modifier = modifier
+            .fillMaxSize()
+            .imePadding()
     ) {
         val (header, body, footer) = createRefs()
 
@@ -67,7 +74,8 @@ fun ForgotPasswordScreen(
                     height = Dimension.fillToConstraints
                 }
                 .padding(top = 20.dp),
-            validateFields = uiState.validateFields
+            validateFields = uiState.validateFields,
+            applyImePadding = false
         ) { uiAction ->
             handleAction(uiAction, viewModel)
         }

--- a/app/src/main/java/com/skgtecnologia/sisem/ui/sections/BodySection.kt
+++ b/app/src/main/java/com/skgtecnologia/sisem/ui/sections/BodySection.kt
@@ -135,6 +135,11 @@ fun BodySection(
     body: List<BodyRowModel>?,
     modifier: Modifier = Modifier,
     validateFields: Boolean = false,
+    // Insetting the list only works when the body can grow; on screens whose body is
+    // pinned between a header and a footer the padding eats the fixed height instead and
+    // the content vanishes behind the keyboard. Those screens inset the whole layout and
+    // opt out here. See ForgotPasswordScreen.
+    applyImePadding: Boolean = true,
     onAction: (actionInput: UiAction) -> Unit
 ) {
     val listState = rememberLazyListState()
@@ -150,7 +155,7 @@ fun BodySection(
             }
 
             LazyColumn(
-                modifier = updatedModifier.imePadding(),
+                modifier = if (applyImePadding) updatedModifier.imePadding() else updatedModifier,
                 state = listState,
                 contentPadding = PaddingValues(horizontal = 20.dp, vertical = 8.dp),
                 verticalArrangement = Arrangement.spacedBy(0.dp, Alignment.Top),


### PR DESCRIPTION
## Description

Reported by @AlejandroAcevedoSkg from testing at the Secretaría de Salud, with video, on a **Motorola G47**: on *"Olvidó su contraseña"*, opening the keyboard makes the email field, the helper text and the **Cancelar / Enviar** buttons disappear. Only the title stays, above an empty gap — the user is left tapping nothing.

Frames from the video, before and after the keyboard opens:

| Keyboard closed | Keyboard open |
|---|---|
| title, email field, helper text, both buttons | title only, then empty space |

### Root cause

The screen is a `ConstraintLayout` with header / body / footer, where the body is pinned between the other two with `Dimension.fillToConstraints` — its height is already decided. `BodySection` then applies `imePadding()` to the `LazyColumn` **inside** that fixed-height body.

So the inset never pushes content upward; it consumes the body's own height. Where the keyboard is short relative to the screen there is height to spare and nothing looks wrong. Once the keyboard is tall enough — as on this device — it takes the whole body and the content collapses to nothing. Meanwhile the footer is anchored to `parent.bottom`, so it sits behind the keyboard regardless.

Nothing here is Motorola-specific: it is a threshold, and this device is simply the first to cross it.

### Fix

Inset the `ConstraintLayout` itself, so the footer rises above the keyboard and the body keeps the remaining height, and let `BodySection` skip its own inset through a new `applyImePadding` parameter.

### Scope — deliberately limited

**19 screens share this exact arrangement** (login, change password, device auth, medical history, vital signs, medicine, inventory, incidents, stretcher retention, signatures…). They all carry the same latent defect and would all be fixed the same way.

This PR changes **only** the reported screen. `applyImePadding` defaults to `true`, so the other 18 behave exactly as today. The reason is verification: there is no working emulator on the dev machine and no Motorola on hand, so this fix is reasoned from the layout, not observed. Rolling it across 19 screens on that basis would hand QA half the app to revalidate.

Once QA confirms this screen on the device, the same change can be applied to the rest in batches.

Bumps to **2.4.6 (89)** — QA already holds 2.4.5.

## Testing

`ktlintCheck`, `detekt`, `testDebugUnitTest` and `verifyPaparazziDebug` pass. Paparazzi snapshots are unchanged, as expected: they render without an IME, which is precisely the state where the bug does not appear — so they neither prove nor disprove the fix. Device verification by QA is the real check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)