### PR TITLE
fix: open the change-password screen when the warning is dismissed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Ajustes y correcciones aplicadas segun versiones:
 ----------------------------------------
 ### Correcciones
 
+- **Contraseña vencida:** Se corrige un problema donde, al cerrar el aviso *"Su contraseña se ha vencido"*, el usuario quedaba en la pantalla de inicio de sesión sin ninguna opción para cambiarla. Ahora al cerrar el aviso se abre directamente la pantalla de cambio de contraseña.
+
 - **Recuperar contraseña en pantallas pequeñas:** Se corrige un problema donde, al abrir el teclado en la pantalla *"Olvidó su contraseña"*, desaparecían el campo de correo y los botones Cancelar y Enviar, dejando la pantalla inutilizable. Se presentaba en equipos donde el teclado ocupa una porción mayor de la pantalla, como el Motorola G47. Ahora el contenido y los botones permanecen visibles sobre el teclado.
 
 # version 2.4.5 *(26.07.2026)*

--- a/app/src/main/java/com/skgtecnologia/sisem/ui/login/LoginScreen.kt
+++ b/app/src/main/java/com/skgtecnologia/sisem/ui/login/LoginScreen.kt
@@ -90,9 +90,15 @@ fun LoginScreen(
     }
 
     OnBannerHandler(uiState.warning) {
+        // Read the destination before consuming it: uiState is backed by the collected
+        // flow, so once consumeNavigationEvent clears it there is nothing left to
+        // navigate to and dismissing the expired-password warning strands the user on
+        // the login screen (SMA-757).
+        val navigationModel = uiState.navigationModel
+
         viewModel.consumeNavigationEvent()
         viewModel.consumeWarningEvent()
-        uiState.navigationModel?.let { navigationModel -> onNavigation(navigationModel) }
+        navigationModel?.let { onNavigation(it) }
     }
 
     OnBannerHandler(uiState.errorModel) {


### PR DESCRIPTION
Closes #299 — Jira [SMA-757](https://skgtecnologia.atlassian.net/browse/SMA-757)

## Root cause

`LoginScreen` handled the expired-password banner like this:

```kotlin
viewModel.consumeNavigationEvent()   // clears navigationModel
viewModel.consumeWarningEvent()
uiState.navigationModel?.let { onNavigation(it) }   // reads it afterwards
```

`uiState` comes from `collectAsStateWithLifecycle()`, so the last line reads the current value — which the first line has already set to `null`. The navigation never fires, the banner closes, and the user is left on the login screen. The message tells them to press a *Cambiar contraseña* button that was never going to appear.

`ChangePasswordScreen` and its route already exist (`isWarning == true → ChangePasswordRoute`); they were simply never reached from here.

## Fix

Capture the destination before consuming it.

## Scope and limits

- **Not verified on a device.** The reasoning explains the reported symptom and the fix is deterministic where the old code was order-dependent, but no emulator on the dev machine runs this app. QA should confirm with an account whose password has expired.
- **HU 00014 not fully checked.** The ticket requires meeting *HU 00014 CA — Seleccionar cambiar contraseña*, whose PDF is attached in Jira and could not be read here. This fixes the reported behaviour; if the HU also requires, say, a permanent button on the login screen, that is still outstanding.
- **15 other screens share the same shape** (consume, then read `uiState.navigationModel`). They work today, so the shape alone is not proof of a defect — it is fragile rather than broken, and worth a separate cleanup pass rather than a blind change now.

## Testing

`ktlintCheck`, `detekt` and `testDebugUnitTest` pass. Changelog entry added under 2.4.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)