### PR TITLE
fix: keep the footer buttons above the keyboard on the remaining screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Ajustes y correcciones aplicadas segun versiones:
 
 
 
+# version 2.4.7 *(27.07.2026)*
+----------------------------------------
+### Correcciones
+
+- **Teclado en pantallas con botones fijos:** Se extiende a otras pantallas la corrección aplicada en la 2.4.6 a *"Olvidó su contraseña"*. Al abrir el teclado en *Cambio de contraseña*, *Autenticación del dispositivo*, *Firma*, *Registro de firma*, *Novedades* e *Inventario (detalle)*, el contenido y los botones inferiores quedaban ocultos o inaccesibles en equipos donde el teclado ocupa una porción mayor de la pantalla, como el Motorola G47. Ahora los botones se elevan sobre el teclado y el contenido permanece visible.
+
 # version 2.4.6 *(27.07.2026)*
 ----------------------------------------
 ### Correcciones

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -44,8 +44,8 @@ android {
         applicationId = "com.skgtecnologia.sisem"
         minSdk = 30
         targetSdk = 36
-        versionCode = 89
-        versionName = "2.4.6"
+        versionCode = 90
+        versionName = "2.4.7"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/skgtecnologia/sisem/ui/changepassword/ChangePasswordScreen.kt
+++ b/app/src/main/java/com/skgtecnologia/sisem/ui/changepassword/ChangePasswordScreen.kt
@@ -1,6 +1,7 @@
 package com.skgtecnologia.sisem.ui.changepassword
 
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -43,7 +44,12 @@ fun ChangePasswordScreen(
     }
 
     ConstraintLayout(
-        modifier = modifier.fillMaxSize()
+        // The body is pinned between the header and the footer, so insetting it for the
+        // keyboard eats its fixed height instead of scrolling. Inset the whole layout so
+        // the footer rises above the keyboard and the body keeps the rest.
+        modifier = modifier
+            .fillMaxSize()
+            .imePadding()
     ) {
         val (header, body, footer) = createRefs()
 
@@ -67,7 +73,8 @@ fun ChangePasswordScreen(
                     height = Dimension.fillToConstraints
                 }
                 .padding(top = 20.dp),
-            validateFields = uiState.validateFields
+            validateFields = uiState.validateFields,
+            applyImePadding = false
         ) { uiAction ->
             handleAction(uiAction, viewModel)
         }

--- a/app/src/main/java/com/skgtecnologia/sisem/ui/deviceauth/DeviceAuthScreen.kt
+++ b/app/src/main/java/com/skgtecnologia/sisem/ui/deviceauth/DeviceAuthScreen.kt
@@ -1,6 +1,7 @@
 package com.skgtecnologia.sisem.ui.deviceauth
 
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -43,7 +44,12 @@ fun DeviceAuthScreen(
     }
 
     ConstraintLayout(
-        modifier = modifier.fillMaxSize()
+        // The body is pinned between the header and the footer, so insetting it for the
+        // keyboard eats its fixed height instead of scrolling. Inset the whole layout so
+        // the footer rises above the keyboard and the body keeps the rest.
+        modifier = modifier
+            .fillMaxSize()
+            .imePadding()
     ) {
         val (header, body, footer) = createRefs()
 
@@ -67,7 +73,8 @@ fun DeviceAuthScreen(
                     height = Dimension.fillToConstraints
                 }
                 .padding(top = 20.dp),
-            validateFields = uiState.validateFields
+            validateFields = uiState.validateFields,
+            applyImePadding = false
         ) { uiAction ->
             handleAction(uiAction, viewModel)
         }

--- a/app/src/main/java/com/skgtecnologia/sisem/ui/inventory/view/InventoryViewScreen.kt
+++ b/app/src/main/java/com/skgtecnologia/sisem/ui/inventory/view/InventoryViewScreen.kt
@@ -1,6 +1,7 @@
 package com.skgtecnologia.sisem.ui.inventory.view
 
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -53,7 +54,11 @@ fun InventoryViewScreen(
     }
 
     ConstraintLayout(
-        modifier = modifier.fillMaxSize()
+        // The footer is anchored to the bottom of the layout, so insetting only the body
+        // leaves the footer buttons behind the keyboard. Inset the whole layout instead.
+        modifier = modifier
+            .fillMaxSize()
+            .imePadding()
     ) {
         val (header, body, footer) = createRefs()
 
@@ -79,7 +84,8 @@ fun InventoryViewScreen(
                 bottom.linkTo(parent.bottom)
                 height = Dimension.fillToConstraints
             },
-            validateFields = uiState.validateFields
+            validateFields = uiState.validateFields,
+            applyImePadding = false
         ) { uiAction ->
             handleAction(uiAction, viewModel)
         }

--- a/app/src/main/java/com/skgtecnologia/sisem/ui/report/addreport/AddReportRoleScreen.kt
+++ b/app/src/main/java/com/skgtecnologia/sisem/ui/report/addreport/AddReportRoleScreen.kt
@@ -1,6 +1,7 @@
 package com.skgtecnologia.sisem.ui.report.addreport
 
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -41,7 +42,12 @@ fun AddReportRoleScreen(
     }
 
     ConstraintLayout(
-        modifier = modifier.fillMaxSize()
+        // The body is pinned between the header and the footer, so insetting it for the
+        // keyboard eats its fixed height instead of scrolling. Inset the whole layout so
+        // the footer rises above the keyboard and the body keeps the rest.
+        modifier = modifier
+            .fillMaxSize()
+            .imePadding()
     ) {
         val (header, body, footer) = createRefs()
 
@@ -64,7 +70,8 @@ fun AddReportRoleScreen(
                     bottom.linkTo(footer.top)
                     height = Dimension.fillToConstraints
                 }
-                .padding(top = 20.dp)
+                .padding(top = 20.dp),
+            applyImePadding = false
         ) { uiAction ->
             handleUiAction(uiAction, onNavigation)
         }

--- a/app/src/main/java/com/skgtecnologia/sisem/ui/sections/BodySection.kt
+++ b/app/src/main/java/com/skgtecnologia/sisem/ui/sections/BodySection.kt
@@ -138,7 +138,7 @@ fun BodySection(
     // Insetting the list only works when the body can grow; on screens whose body is
     // pinned between a header and a footer the padding eats the fixed height instead and
     // the content vanishes behind the keyboard. Those screens inset the whole layout and
-    // opt out here. See ForgotPasswordScreen.
+    // opt out here — grep for `applyImePadding = false` to find them.
     applyImePadding: Boolean = true,
     onAction: (actionInput: UiAction) -> Unit
 ) {

--- a/app/src/main/java/com/skgtecnologia/sisem/ui/signature/init/InitSignatureScreen.kt
+++ b/app/src/main/java/com/skgtecnologia/sisem/ui/signature/init/InitSignatureScreen.kt
@@ -1,6 +1,7 @@
 package com.skgtecnologia.sisem.ui.signature.init
 
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -56,7 +57,12 @@ fun InitSignatureScreen(
     }
 
     ConstraintLayout(
-        modifier = modifier.fillMaxSize()
+        // The body is pinned between the header and the footer, so insetting it for the
+        // keyboard eats its fixed height instead of scrolling. Inset the whole layout so
+        // the footer rises above the keyboard and the body keeps the rest.
+        modifier = modifier
+            .fillMaxSize()
+            .imePadding()
     ) {
         val (header, body, footer) = createRefs()
 
@@ -84,7 +90,8 @@ fun InitSignatureScreen(
                     height = Dimension.fillToConstraints
                 }
                 .padding(top = 20.dp),
-            validateFields = uiState.validateFields
+            validateFields = uiState.validateFields,
+            applyImePadding = false
         ) { uiAction ->
             handleAction(uiAction, viewModel)
         }

--- a/app/src/main/java/com/skgtecnologia/sisem/ui/signature/view/SignatureScreen.kt
+++ b/app/src/main/java/com/skgtecnologia/sisem/ui/signature/view/SignatureScreen.kt
@@ -1,6 +1,7 @@
 package com.skgtecnologia.sisem.ui.signature.view
 
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -59,7 +60,12 @@ fun SignatureScreen(
     }
 
     ConstraintLayout(
-        modifier = modifier.fillMaxSize()
+        // The body is pinned between the header and the footer, so insetting it for the
+        // keyboard eats its fixed height instead of scrolling. Inset the whole layout so
+        // the footer rises above the keyboard and the body keeps the rest.
+        modifier = modifier
+            .fillMaxSize()
+            .imePadding()
     ) {
         val (header, body, footer) = createRefs()
 
@@ -86,7 +92,8 @@ fun SignatureScreen(
                     bottom.linkTo(footer.top)
                     height = Dimension.fillToConstraints
                 }
-                .padding(top = 20.dp)
+                .padding(top = 20.dp),
+            applyImePadding = false
         ) { }
 
         uiState.screenModel?.footer?.let {


### PR DESCRIPTION
## Contexto

La [#297](https://github.com/Valkiria-Project/SISEM-Android/pull/297) corrigió la pantalla *Olvidó su contraseña*, donde al abrir el teclado en un Motorola G47 desaparecían el campo de correo y los botones Cancelar/Enviar.

Ese no es un problema de una pantalla: es del patrón de layout. Cuando el `body` queda fijado entre el `header` y un `footer` anclado a `parent.bottom`, su altura es fija. `BodySection` aplicaba `imePadding()` al `LazyColumn` interno, así que el teclado se descontaba de esa altura ya reducida en lugar de hacer scroll, y el footer se quedaba detrás del teclado.

## Cambio

Se aplica el mismo arreglo de la #297 a las pantallas restantes con ese patrón: se inserta el `imePadding()` en el `ConstraintLayout` completo y el `BodySection` se excluye con `applyImePadding = false`.

| Pantalla | Situación |
|---|---|
| `ChangePasswordScreen` | body entre header y footer |
| `DeviceAuthScreen` | body entre header y footer |
| `InitSignatureScreen` | body entre header y footer |
| `SignatureScreen` | body entre header y footer |
| `AddReportRoleScreen` | body entre header y footer |
| `InventoryViewScreen` | variante leve: el body llega hasta abajo, pero el footer quedaba tapado |

## Lo que **no** se tocó

Las pantallas sin footer (`LoginScreen`, `IncidentScreen`, `MedicalHistoryScreen`, `VitalSignsScreen`, `MedicineScreen`, `InventoryScreen`, `AuthCardsScreen`, `AuthCardViewScreen`, `StretcherRetention*`, `PreOperational*`) se dejaron igual: ahí el body crece hasta el borde inferior de la pantalla, así que insertar el padding en el `LazyColumn` ya se comporta bien y el contenido hace scroll.

Es decir, el patrón aparece en ~19 pantallas pero el defecto solo estaba en 6.

## Verificación

- `compileDebugKotlin`, `ktlintCheck`, `detekt` ✅
- `testDebugUnitTest` ✅
- `verifyPaparazziDebug` ✅
- Falta validación en dispositivo real (Motorola G47) por parte de QA.

Sube la versión a **2.4.7 (90)** para que QA pueda distinguir el binario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)