### PR TITLE
chore: drop what the session-close refactor left behind

### DIFF
--- a/app/src/main/java/com/skgtecnologia/sisem/data/auth/remote/AuthApi.kt
+++ b/app/src/main/java/com/skgtecnologia/sisem/data/auth/remote/AuthApi.kt
@@ -33,13 +33,6 @@ interface AuthApi {
         @Field("scope") scope: String = "offline_access"
     ): Response<RefreshTokenResponse>
 
-    /**
-     * Closes whatever session the user has open elsewhere. This goes straight to Keycloak
-     * rather than through the SISEM API, on the same token endpoint the refresh call uses.
-     * It authenticates as a side effect and hands back tokens, but we deliberately drop
-     * them: the user stays on the login screen and signs in again through `auth`, which is
-     * the only call that returns the role, turn and preoperational data the app needs.
-     */
     @GET("auth/logout")
     suspend fun logout(
         @Header("username") username: String,

--- a/app/src/main/java/com/skgtecnologia/sisem/ui/login/LoginScreen.kt
+++ b/app/src/main/java/com/skgtecnologia/sisem/ui/login/LoginScreen.kt
@@ -112,10 +112,6 @@ fun LoginScreen(
         }
     }
 
-    OnBannerHandler(uiState.successBanner) {
-        viewModel.consumeSuccessEvent()
-    }
-
     OnLoadingHandler(uiState.isLoading, modifier)
 }
 

--- a/app/src/main/java/com/skgtecnologia/sisem/ui/login/LoginUiState.kt
+++ b/app/src/main/java/com/skgtecnologia/sisem/ui/login/LoginUiState.kt
@@ -11,8 +11,5 @@ data class LoginUiState(
     val navigationModel: LoginNavigationModel? = null,
     val isLoading: Boolean = false,
     val warning: BannerUiModel? = null,
-    val errorModel: BannerUiModel? = null,
-    // Kept apart from `warning`, which navigates to the change-password screen when it is
-    // dismissed. This one only confirms the other session was closed and stays put.
-    val successBanner: BannerUiModel? = null
+    val errorModel: BannerUiModel? = null
 )

--- a/app/src/main/java/com/skgtecnologia/sisem/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/com/skgtecnologia/sisem/ui/login/LoginViewModel.kt
@@ -247,14 +247,6 @@ class LoginViewModel @Inject constructor(
         }
     }
 
-    fun consumeSuccessEvent() {
-        uiState.update {
-            it.copy(
-                successBanner = null
-            )
-        }
-    }
-
     fun consumeWarningEvent() {
         uiState.update {
             it.copy(

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -26,9 +26,6 @@
     <string name="error_unauthorized_cta">Re Autenticar</string>
     <string name="close_session_confirm_cta">SÍ</string>
     <string name="close_session_cancel_cta">NO</string>
-    <string name="close_session_success_icon">ic_duplicated</string>
-    <string name="close_session_success_title">Sesión cerrada</string>
-    <string name="close_session_success_description">La sesión en el otro dispositivo se cerró correctamente. Ya puede iniciar sesión aquí.</string>
     <string name="error_general_title">Ha ocurrido un error</string>
     <string name="error_general_description">Intenta más tarde</string>
     <string name="error_server_title">Servicio no disponible</string>

--- a/app/src/test/java/com/skgtecnologia/sisem/ui/login/LoginViewModelTest.kt
+++ b/app/src/test/java/com/skgtecnologia/sisem/ui/login/LoginViewModelTest.kt
@@ -280,16 +280,6 @@ class LoginViewModelTest {
         Assert.assertEquals(false, loginViewModel.uiState.value.isLoading)
     }
 
-    @Test
-    fun `when call consumeSuccessEvent uiState should have successBanner clear`() = runTest {
-        coEvery { getLoginScreen.invoke(ANDROID_ID) } returns Result.success(emptyScreenModel)
-
-        loginViewModel = createViewModel()
-        loginViewModel.consumeSuccessEvent()
-
-        Assert.assertEquals(null, loginViewModel.uiState.value.successBanner)
-    }
-
     private fun createAccessToken(warning: BannerModel?) = AccessTokenModel(
         userId = 1,
         dateTime = LocalDateTime.now(),


### PR DESCRIPTION
Limpieza de restos que quedaron al mover el cierre de sesión al flujo de login (el refactor que llegó de GitLab en el #304). El refactor eliminó las piezas para las que esto se escribió, pero no esto:

| Resto | Estado |
|---|---|
| KDoc en `AuthApi` | Describía la llamada a Keycloak ya borrada; quedó pegado a `logout()`, documentando algo que esa función no hace |
| `successBanner` en `LoginUiState` | Lo lee `LoginScreen` y lo limpia `consumeSuccessEvent`, pero **nadie lo asigna** |
| `close_session_success_*` (3 strings) | Alimentaban ese banner |

El `successBanner` de `ForgotPassword` es otra función, viva y sin tocar.

Sin cambio de comportamiento: se borra código que ya no se ejecutaba y una documentación que era falsa.

## Verificación

`lintDebug`, `ktlintCheck`, `detekt`, `testDebugUnitTest`, `verifyPaparazziDebug` ✅

Versión sin cambios: 2.4.11 (94).

🤖 Generated with [Claude Code](https://claude.com/claude-code)