### PR TITLE
perf: stop re-reading the position on every request

### DIFF
--- a/app/src/main/java/com/skgtecnologia/sisem/data/remote/interceptors/AuditInterceptor.kt
+++ b/app/src/main/java/com/skgtecnologia/sisem/data/remote/interceptors/AuditInterceptor.kt
@@ -27,6 +27,13 @@ private const val IP_ADDRESS_HEADER = "x-ip"
 private const val UNAVAILABLE_IP_ADDRESS = "UNAVAILABLE_LOCATION"
 private const val IP_CACHE_TTL_MS = 10 * 60 * 1000L
 
+// Far shorter than the IP one, and deliberately so: an IP barely changes over a shift,
+// a moving ambulance does. This is only meant to collapse the burst of calls a single
+// user action fires - saving a record hits the API several times in a row, and each of
+// those was paying up to AUDIT_TIMEOUT for a position that had not meaningfully moved.
+// At highway speed five seconds is under a hundred metres.
+private const val LOCATION_CACHE_TTL_MS = 5 * 1000L
+
 @Singleton
 class AuditInterceptor @Inject constructor(
     private val fusedLocationClient: FusedLocationProviderClient
@@ -37,6 +44,12 @@ class AuditInterceptor @Inject constructor(
 
     @Volatile
     private var ipCachedAt: Long = 0L
+
+    @Volatile
+    private var cachedLocation: String? = null
+
+    @Volatile
+    private var locationCachedAt: Long = 0L
 
     private val ipClient = OkHttpClient()
 
@@ -53,21 +66,34 @@ class AuditInterceptor @Inject constructor(
     }
 
     private fun Request.Builder.withCurrentLocation(): Request.Builder = runBlocking {
-        val location = runCatching {
-            withTimeout(AUDIT_TIMEOUT) {
-                fusedLocationClient
-                    .locationFlow()
-                    .catch { throwable ->
-                        Timber.d("Unable to get location $throwable")
-                    }
-                    .first()
-            }
-        }.getOrNull()
+        val now = System.currentTimeMillis()
+        val cached = cachedLocation
 
-        val formattedLocation = if (location != null) {
-            "${location.latitude}, ${location.longitude}"
+        val formattedLocation = if (cached != null && now - locationCachedAt < LOCATION_CACHE_TTL_MS) {
+            cached
         } else {
-            UNAVAILABLE_LOCATION
+            val location = runCatching {
+                withTimeout(AUDIT_TIMEOUT) {
+                    fusedLocationClient
+                        .locationFlow()
+                        .catch { throwable ->
+                            Timber.d("Unable to get location $throwable")
+                        }
+                        .first()
+                }
+            }.getOrNull()
+
+            // Unlike the IP, an expired position is not reused when the read fails. This
+            // header ends up in an audit trail, and placing a crew where they no longer
+            // are is worse than admitting we do not know.
+            if (location != null) {
+                "${location.latitude}, ${location.longitude}".also {
+                    cachedLocation = it
+                    locationCachedAt = now
+                }
+            } else {
+                UNAVAILABLE_LOCATION
+            }
         }
 
         this@withCurrentLocation.header(

--- a/app/src/test/java/com/skgtecnologia/sisem/data/remote/interceptors/AuditInterceptorTest.kt
+++ b/app/src/test/java/com/skgtecnologia/sisem/data/remote/interceptors/AuditInterceptorTest.kt
@@ -1,0 +1,106 @@
+package com.skgtecnologia.sisem.data.remote.interceptors
+
+import android.location.Location
+import com.google.android.gms.location.FusedLocationProviderClient
+import com.skgtecnologia.sisem.ui.commons.extensions.locationFlow
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import io.mockk.mockkConstructor
+import io.mockk.mockkStatic
+import io.mockk.unmockkConstructor
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import kotlinx.coroutines.flow.flowOf
+import okhttp3.Interceptor
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import java.io.IOException
+
+private const val LOCATION_EXTENSIONS =
+    "com.skgtecnologia.sisem.ui.commons.extensions.LocationExtensionsKt"
+private const val GEOLOCATION_HEADER = "geolocation"
+private const val UNAVAILABLE = "UNAVAILABLE_LOCATION"
+
+class AuditInterceptorTest {
+
+    @MockK
+    private lateinit var fusedLocationClient: FusedLocationProviderClient
+
+    @MockK
+    private lateinit var chain: Interceptor.Chain
+
+    private lateinit var interceptor: AuditInterceptor
+    private val sentRequests = mutableListOf<Request>()
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this)
+        mockkStatic(LOCATION_EXTENSIONS)
+
+        // The IP lookup builds its own OkHttpClient. Make it fail so the test stays off
+        // the network; the interceptor already degrades to a placeholder header.
+        mockkConstructor(OkHttpClient::class)
+        every { constructedWith<OkHttpClient>().newCall(any()) } throws IOException("offline")
+
+        interceptor = AuditInterceptor(fusedLocationClient)
+
+        val request = Request.Builder().url("https://example.com/api/data").build()
+        every { chain.request() } returns request
+        every { chain.proceed(capture(sentRequests)) } answers {
+            Response.Builder()
+                .request(request)
+                .protocol(Protocol.HTTP_1_1)
+                .code(200)
+                .message("OK")
+                .build()
+        }
+    }
+
+    @After
+    fun teardown() {
+        unmockkStatic(LOCATION_EXTENSIONS)
+        unmockkConstructor(OkHttpClient::class)
+        sentRequests.clear()
+    }
+
+    private fun givenLocation(latitude: Double, longitude: Double) {
+        val location = mockk<Location>()
+        every { location.latitude } returns latitude
+        every { location.longitude } returns longitude
+        every { fusedLocationClient.locationFlow() } returns flowOf(location)
+    }
+
+    @Test
+    fun `the location is read once and reused while the entry is fresh`() {
+        givenLocation(latitude = 4.60971, longitude = -74.08175)
+
+        repeat(3) { interceptor.intercept(chain) }
+
+        verify(exactly = 1) { fusedLocationClient.locationFlow() }
+        Assert.assertEquals(3, sentRequests.size)
+        sentRequests.forEach {
+            Assert.assertEquals("4.60971, -74.08175", it.header(GEOLOCATION_HEADER))
+        }
+    }
+
+    @Test
+    fun `a failed read reports the position as unavailable instead of guessing`() {
+        every { fusedLocationClient.locationFlow() } returns flowOf()
+
+        interceptor.intercept(chain)
+
+        Assert.assertEquals(UNAVAILABLE, sentRequests.single().header(GEOLOCATION_HEADER))
+    }
+
+    // Expiry itself is not covered: the interceptor reads System.currentTimeMillis()
+    // directly, so a test would have to sleep out the TTL. Making it verifiable means
+    // injecting a clock, which is more than this change is worth on its own.
+}


### PR DESCRIPTION
## El problema

`AuditInterceptor` agrega una cabecera `geolocation` a **cada** petición HTTP. Hasta ahora cada una arrancaba una lectura nueva de ubicación y esperaba hasta `AUDIT_TIMEOUT` (1 segundo) por ella.

Guardar una historia clínica dispara varias llamadas seguidas, así que **una sola acción del usuario podía pagar esa espera varias veces** por una posición que no se había movido de forma significativa. En una ambulancia con señal intermitente —el escenario real— eso se acumula.

La IP que está al lado ya tenía caché (Alejandro la agregó). La ubicación no.

## El cambio

Se le aplica el mismo patrón, con un TTL mucho más corto: **5 segundos** contra los 10 minutos de la IP. Una IP casi no cambia en un turno; una ambulancia sí. A velocidad de vía rápida, 5 segundos son menos de 100 metros — alcanza para colapsar una ráfaga de llamadas sin ensuciar la traza de auditoría.

**Una diferencia deliberada con la IP:** cuando la lectura falla, **no** se reutiliza una posición vencida. Esta cabecera termina en un registro de auditoría, y ubicar a una tripulación donde ya no está es peor que admitir que no se sabe. La IP sí puede caer a su último valor porque no tiene ese problema.

## Tests

Son los primeros del interceptor. Cubren que la posición se lee una sola vez dentro del TTL y que una lectura fallida reporta `UNAVAILABLE_LOCATION`.

La expiración quedó **sin cubrir a propósito**: la clase lee `System.currentTimeMillis()` directo, así que verificarla implica inyectar un reloj — más de lo que justifica este cambio. Está anotado en el archivo de test.

Para que las pruebas no salgan a la red, se intercepta el `OkHttpClient` que la búsqueda de IP construye internamente.

## Verificación

`lintDebug`, `ktlintCheck`, `detekt`, `testDebugUnitTest`, `verifyPaparazziDebug` ✅

Sin cambio de versión: 2.4.11 (94).

🤖 Generated with [Claude Code](https://claude.com/claude-code)