### PR TITLE
test: cover the incident and map view models

### DIFF
--- a/app/src/test/java/com/skgtecnologia/sisem/ui/incident/IncidentViewModelTest.kt
+++ b/app/src/test/java/com/skgtecnologia/sisem/ui/incident/IncidentViewModelTest.kt
@@ -1,0 +1,169 @@
+package com.skgtecnologia.sisem.ui.incident
+
+import com.skgtecnologia.sisem.commons.MainDispatcherRule
+import com.skgtecnologia.sisem.commons.SERVER_ERROR_TITLE
+import com.skgtecnologia.sisem.commons.USERNAME
+import com.skgtecnologia.sisem.commons.communication.UnauthorizedEventHandler
+import com.skgtecnologia.sisem.commons.emptyScreenModel
+import com.skgtecnologia.sisem.domain.auth.usecases.LogoutCurrentUser
+import com.skgtecnologia.sisem.domain.incident.usecases.GetIncidentScreen
+import com.skgtecnologia.sisem.domain.login.model.LoginIdentifier
+import com.valkiria.uicomponents.action.FooterUiAction
+import com.valkiria.uicomponents.action.GenericUiAction
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.just
+import io.mockk.mockkObject
+import io.mockk.runs
+import io.mockk.unmockkObject
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+private const val APH_IDENTIFIER = "APH-123"
+
+class IncidentViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @MockK
+    private lateinit var getIncidentScreen: GetIncidentScreen
+
+    @MockK
+    private lateinit var logoutCurrentUser: LogoutCurrentUser
+
+    private lateinit var incidentViewModel: IncidentViewModel
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this)
+        mockkObject(UnauthorizedEventHandler)
+        every { UnauthorizedEventHandler.publishUnauthorizedEvent(any()) } just runs
+    }
+
+    @After
+    fun teardown() {
+        unmockkObject(UnauthorizedEventHandler)
+    }
+
+    private suspend fun givenScreenLoads() {
+        coEvery { getIncidentScreen.invoke() } returns Result.success(emptyScreenModel)
+    }
+
+    @Test
+    fun `when the screen loads it is exposed and the loader is cleared`() = runTest {
+        givenScreenLoads()
+
+        incidentViewModel = IncidentViewModel(getIncidentScreen, logoutCurrentUser)
+
+        Assert.assertEquals(emptyScreenModel, incidentViewModel.uiState.screenModel)
+        Assert.assertEquals(false, incidentViewModel.uiState.isLoading)
+        Assert.assertEquals(null, incidentViewModel.uiState.infoEvent)
+    }
+
+    @Test
+    fun `when the screen fails to load the error is surfaced`() = runTest {
+        coEvery { getIncidentScreen.invoke() } returns Result.failure(Throwable())
+
+        incidentViewModel = IncidentViewModel(getIncidentScreen, logoutCurrentUser)
+
+        Assert.assertEquals(SERVER_ERROR_TITLE, incidentViewModel.uiState.infoEvent?.title)
+        Assert.assertEquals(false, incidentViewModel.uiState.isLoading)
+        Assert.assertEquals(null, incidentViewModel.uiState.screenModel)
+    }
+
+    @Test
+    fun `when goBack is called the navigation asks to go back`() = runTest {
+        givenScreenLoads()
+
+        incidentViewModel = IncidentViewModel(getIncidentScreen, logoutCurrentUser)
+        incidentViewModel.goBack()
+
+        Assert.assertEquals(true, incidentViewModel.uiState.navigationModel?.back)
+    }
+
+    @Test
+    fun `when navigating to stretcher retention the identifier travels along`() = runTest {
+        givenScreenLoads()
+
+        incidentViewModel = IncidentViewModel(getIncidentScreen, logoutCurrentUser)
+        incidentViewModel.navigateToStretcherRetention(APH_IDENTIFIER)
+
+        Assert.assertEquals(
+            APH_IDENTIFIER,
+            incidentViewModel.uiState.navigationModel?.stretcherRetentionAph
+        )
+    }
+
+    @Test
+    fun `when navigating to the medical history the patient travels along`() = runTest {
+        givenScreenLoads()
+
+        incidentViewModel = IncidentViewModel(getIncidentScreen, logoutCurrentUser)
+        incidentViewModel.navigateToAphView(APH_IDENTIFIER)
+
+        Assert.assertEquals(
+            APH_IDENTIFIER,
+            incidentViewModel.uiState.navigationModel?.patientAph
+        )
+    }
+
+    @Test
+    fun `when the navigation event is consumed the destination is cleared`() = runTest {
+        givenScreenLoads()
+
+        incidentViewModel = IncidentViewModel(getIncidentScreen, logoutCurrentUser)
+        incidentViewModel.goBack()
+        incidentViewModel.consumeNavigationEvent()
+
+        Assert.assertEquals(null, incidentViewModel.uiState.navigationModel)
+        Assert.assertEquals(false, incidentViewModel.uiState.isLoading)
+    }
+
+    @Test
+    fun `the re-auth banner logs the user out and announces it`() = runTest {
+        givenScreenLoads()
+        coEvery { logoutCurrentUser.invoke() } returns Result.success(USERNAME)
+
+        incidentViewModel = IncidentViewModel(getIncidentScreen, logoutCurrentUser)
+        incidentViewModel.handleEvent(
+            FooterUiAction.FooterButton(LoginIdentifier.LOGIN_RE_AUTH_BANNER.name)
+        )
+
+        coVerify { logoutCurrentUser.invoke() }
+        verify { UnauthorizedEventHandler.publishUnauthorizedEvent(USERNAME) }
+    }
+
+    @Test
+    fun `a failed logout still announces it so the user is not stranded`() = runTest {
+        givenScreenLoads()
+        coEvery { logoutCurrentUser.invoke() } returns Result.failure(Throwable("boom"))
+
+        incidentViewModel = IncidentViewModel(getIncidentScreen, logoutCurrentUser)
+        incidentViewModel.handleEvent(
+            FooterUiAction.FooterButton(LoginIdentifier.LOGIN_RE_AUTH_BANNER.name)
+        )
+
+        verify { UnauthorizedEventHandler.publishUnauthorizedEvent(any()) }
+    }
+
+    @Test
+    fun `any other action only dismisses the banner`() = runTest {
+        coEvery { getIncidentScreen.invoke() } returns Result.failure(Throwable())
+
+        incidentViewModel = IncidentViewModel(getIncidentScreen, logoutCurrentUser)
+        incidentViewModel.handleEvent(GenericUiAction.DismissAction)
+
+        Assert.assertEquals(null, incidentViewModel.uiState.infoEvent)
+        coVerify(exactly = 0) { logoutCurrentUser.invoke() }
+        verify(exactly = 0) { UnauthorizedEventHandler.publishUnauthorizedEvent(any()) }
+    }
+}

--- a/app/src/test/java/com/skgtecnologia/sisem/ui/map/MapViewModelTest.kt
+++ b/app/src/test/java/com/skgtecnologia/sisem/ui/map/MapViewModelTest.kt
@@ -1,0 +1,95 @@
+package com.skgtecnologia.sisem.ui.map
+
+import com.skgtecnologia.sisem.commons.MainDispatcherRule
+import com.skgtecnologia.sisem.domain.incident.usecases.ObserveActiveIncident
+import com.skgtecnologia.sisem.domain.notification.usecases.ObserveNotifications
+import com.valkiria.uicomponents.bricks.notification.NotificationUiModel
+import com.valkiria.uicomponents.components.incident.model.IncidentUiModel
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class MapViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @MockK
+    private lateinit var observeActiveIncident: ObserveActiveIncident
+
+    @MockK
+    private lateinit var observeNotifications: ObserveNotifications
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this)
+    }
+
+    /**
+     * The state is shared WhileSubscribed, so nothing flows until something collects it.
+     * Keeping a collector alive on the background scope is what makes the combine run.
+     */
+    private fun TestScope.subscribedViewModel(): MapViewModel {
+        val viewModel = MapViewModel(observeActiveIncident, observeNotifications)
+        backgroundScope.keepCollecting(viewModel)
+        return viewModel
+    }
+
+    @Test
+    fun `the state starts empty before either source emits`() = runTest(UnconfinedTestDispatcher()) {
+        every { observeActiveIncident.invoke() } returns flowOf()
+        every { observeNotifications.invoke() } returns flowOf()
+
+        val viewModel = subscribedViewModel()
+
+        Assert.assertEquals(MapUiState(), viewModel.uiState.value)
+    }
+
+    @Test
+    fun `both sources are combined into a single state`() = runTest(UnconfinedTestDispatcher()) {
+        val incident = mockk<IncidentUiModel>()
+        val notifications = listOf(mockk<NotificationUiModel>())
+        every { observeActiveIncident.invoke() } returns flowOf(incident)
+        every { observeNotifications.invoke() } returns flowOf(notifications)
+
+        val viewModel = subscribedViewModel()
+
+        Assert.assertEquals(incident, viewModel.uiState.value.incident)
+        Assert.assertEquals(notifications, viewModel.uiState.value.notifications)
+    }
+
+    @Test
+    fun `clearing the active incident does not drop the notifications`() = runTest(UnconfinedTestDispatcher()) {
+        val incident = mockk<IncidentUiModel>()
+        val notifications = listOf(mockk<NotificationUiModel>())
+        val incidents = MutableStateFlow<IncidentUiModel?>(incident)
+        every { observeActiveIncident.invoke() } returns incidents
+        every { observeNotifications.invoke() } returns flowOf(notifications)
+
+        val viewModel = subscribedViewModel()
+        Assert.assertEquals(incident, viewModel.uiState.value.incident)
+
+        // The crew closes the incident: the map has to let go of it, but the
+        // notifications it is showing are not part of that and must survive.
+        incidents.value = null
+
+        Assert.assertEquals(null, viewModel.uiState.value.incident)
+        Assert.assertEquals(notifications, viewModel.uiState.value.notifications)
+    }
+}
+
+private fun CoroutineScope.keepCollecting(viewModel: MapViewModel) {
+    launch { viewModel.uiState.collect { } }
+}


### PR DESCRIPTION
Primera tanda de los 9 ViewModels sin cobertura. Empiezo por estos dos porque están en el camino operativo — es de donde salieron los últimos bugs (mapa congelado, incidencia que no reanuda).

## `IncidentViewModel` — 9 tests

- Carga de pantalla en ambos sentidos (éxito y error)
- Cada destino de navegación y el consumo del evento
- **El banner de re-autenticación**, que es lo que más valor tiene:
  - cierra sesión y publica el evento
  - **un logout fallido igual publica el evento** — si no, un usuario con la sesión caída se queda con un botón muerto
  - cualquier otra acción cierra el banner **sin** desloguear a nadie

## `MapViewModel` — 3 tests

- Que las dos fuentes se combinen en un solo estado
- Que **cerrar la incidencia activa no se lleve las notificaciones por delante**

## Una nota sobre cómo están escritos

`MapViewModel` comparte su estado con `WhileSubscribed`, así que **nada fluye hasta que alguien colecta**. Los tests mantienen un colector vivo en el `backgroundScope`; sin él, el `combine` nunca corre y cada aserción leería el valor inicial y **pasaría por el motivo equivocado**. Está explicado en el archivo para que no se pierda.

Turbine se leería mejor para esto, pero no es dependencia del proyecto y agregar una por dos aserciones no es algo que corresponda decidir de paso. Quedó resuelto con lo que ya hay.

## Estado de la cobertura

De 9 ViewModels sin test pasamos a **7**: `SendEmailViewModel`, `MapFragmentViewModel`, `MedicalHistoryViewViewModel`, `InitSignatureViewModel`, `WoundsViewModel`, `AddReportRoleViewModel`, `PreStretcherRetentionViewModel`.

## Verificación

`lintDebug`, `ktlintCheck`, `detekt`, `testDebugUnitTest`, `verifyPaparazziDebug` ✅

Sin cambios en `main`; solo se agregan tests. Versión sin tocar: 2.4.11 (94).

🤖 Generated with [Claude Code](https://claude.com/claude-code)