### PR TITLE
test: cover the init signature and add report role view models

### DIFF
--- a/app/src/test/java/com/skgtecnologia/sisem/ui/report/addreport/AddReportRoleViewModelTest.kt
+++ b/app/src/test/java/com/skgtecnologia/sisem/ui/report/addreport/AddReportRoleViewModelTest.kt
@@ -1,0 +1,109 @@
+package com.skgtecnologia.sisem.ui.report.addreport
+
+import com.skgtecnologia.sisem.commons.ANDROID_ID
+import com.skgtecnologia.sisem.commons.MainDispatcherRule
+import com.skgtecnologia.sisem.commons.USERNAME
+import com.skgtecnologia.sisem.commons.communication.UnauthorizedEventHandler
+import com.skgtecnologia.sisem.commons.emptyScreenModel
+import com.skgtecnologia.sisem.commons.resources.AndroidIdProvider
+import com.skgtecnologia.sisem.domain.auth.usecases.LogoutCurrentUser
+import com.skgtecnologia.sisem.domain.login.model.LoginIdentifier
+import com.skgtecnologia.sisem.domain.report.usecases.GetAddReportRoleScreen
+import com.valkiria.uicomponents.action.FooterUiAction
+import com.valkiria.uicomponents.action.GenericUiAction
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.just
+import io.mockk.mockkObject
+import io.mockk.runs
+import io.mockk.unmockkObject
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * The screen load is not covered here. It runs on `viewModelScope.launch(Dispatchers.IO)`,
+ * and MainDispatcherRule only swaps out Main - so any assertion on it would be racing a
+ * real background thread and would pass or fail on timing rather than on behaviour.
+ * Covering it means injecting the dispatcher, which is a change to production code and
+ * belongs in its own commit. Everything below runs through Main and is deterministic.
+ */
+class AddReportRoleViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @MockK
+    private lateinit var getAddReportRoleScreen: GetAddReportRoleScreen
+
+    @MockK
+    private lateinit var logoutCurrentUser: LogoutCurrentUser
+
+    @MockK
+    private lateinit var androidIdProvider: AndroidIdProvider
+
+    private lateinit var viewModel: AddReportRoleViewModel
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this)
+        mockkObject(UnauthorizedEventHandler)
+        every { UnauthorizedEventHandler.publishUnauthorizedEvent(any()) } just runs
+        every { androidIdProvider.getAndroidId() } returns ANDROID_ID
+        coEvery { getAddReportRoleScreen.invoke(any()) } returns Result.success(emptyScreenModel)
+    }
+
+    @After
+    fun teardown() {
+        unmockkObject(UnauthorizedEventHandler)
+    }
+
+    private fun createViewModel() = AddReportRoleViewModel(
+        getAddReportRoleScreen,
+        logoutCurrentUser,
+        androidIdProvider
+    )
+
+    @Test
+    fun `the re-auth banner logs the user out and announces it`() = runTest {
+        coEvery { logoutCurrentUser.invoke() } returns Result.success(USERNAME)
+        viewModel = createViewModel()
+
+        viewModel.handleEvent(
+            FooterUiAction.FooterButton(LoginIdentifier.LOGIN_RE_AUTH_BANNER.name)
+        )
+
+        coVerify { logoutCurrentUser.invoke() }
+        verify { UnauthorizedEventHandler.publishUnauthorizedEvent(USERNAME) }
+    }
+
+    @Test
+    fun `a failed logout still announces it so the user is not stranded`() = runTest {
+        coEvery { logoutCurrentUser.invoke() } returns Result.failure(Throwable("boom"))
+        viewModel = createViewModel()
+
+        viewModel.handleEvent(
+            FooterUiAction.FooterButton(LoginIdentifier.LOGIN_RE_AUTH_BANNER.name)
+        )
+
+        verify { UnauthorizedEventHandler.publishUnauthorizedEvent(any()) }
+    }
+
+    @Test
+    fun `any other action only dismisses the banner`() = runTest {
+        viewModel = createViewModel()
+
+        viewModel.handleEvent(GenericUiAction.DismissAction)
+
+        Assert.assertEquals(null, viewModel.uiState.errorModel)
+        coVerify(exactly = 0) { logoutCurrentUser.invoke() }
+        verify(exactly = 0) { UnauthorizedEventHandler.publishUnauthorizedEvent(any()) }
+    }
+}

--- a/app/src/test/java/com/skgtecnologia/sisem/ui/signature/init/InitSignatureViewModelTest.kt
+++ b/app/src/test/java/com/skgtecnologia/sisem/ui/signature/init/InitSignatureViewModelTest.kt
@@ -1,0 +1,198 @@
+package com.skgtecnologia.sisem.ui.signature.init
+
+import com.skgtecnologia.sisem.commons.MainDispatcherRule
+import com.skgtecnologia.sisem.commons.SERVER_ERROR_TITLE
+import com.skgtecnologia.sisem.commons.USERNAME
+import com.skgtecnologia.sisem.commons.communication.UnauthorizedEventHandler
+import com.skgtecnologia.sisem.commons.emptyScreenModel
+import com.skgtecnologia.sisem.domain.auth.usecases.LogoutCurrentUser
+import com.skgtecnologia.sisem.domain.login.model.LoginIdentifier
+import com.skgtecnologia.sisem.domain.signature.usecases.GetInitSignatureScreen
+import com.skgtecnologia.sisem.domain.signature.usecases.SearchDocument
+import com.valkiria.uicomponents.action.FooterUiAction
+import com.valkiria.uicomponents.action.GenericUiAction
+import com.valkiria.uicomponents.components.textfield.InputUiModel
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.just
+import io.mockk.mockkObject
+import io.mockk.runs
+import io.mockk.unmockkObject
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+private const val DOCUMENT = "1032456789"
+
+class InitSignatureViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @MockK
+    private lateinit var getInitSignatureScreen: GetInitSignatureScreen
+
+    @MockK
+    private lateinit var searchDocument: SearchDocument
+
+    @MockK
+    private lateinit var logoutCurrentUser: LogoutCurrentUser
+
+    private lateinit var viewModel: InitSignatureViewModel
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this)
+        mockkObject(UnauthorizedEventHandler)
+        every { UnauthorizedEventHandler.publishUnauthorizedEvent(any()) } just runs
+    }
+
+    @After
+    fun teardown() {
+        unmockkObject(UnauthorizedEventHandler)
+    }
+
+    private suspend fun givenScreenLoads(): InitSignatureViewModel {
+        coEvery { getInitSignatureScreen.invoke() } returns Result.success(emptyScreenModel)
+        return InitSignatureViewModel(getInitSignatureScreen, searchDocument, logoutCurrentUser)
+    }
+
+    private fun InitSignatureViewModel.withTypedDocument(validated: Boolean) {
+        document.value = InputUiModel(
+            identifier = "DOCUMENT",
+            updatedValue = DOCUMENT,
+            fieldValidated = validated
+        )
+    }
+
+    @Test
+    fun `when the screen loads it is exposed and the loader is cleared`() = runTest {
+        viewModel = givenScreenLoads()
+
+        Assert.assertEquals(emptyScreenModel, viewModel.uiState.screenModel)
+        Assert.assertEquals(false, viewModel.uiState.isLoading)
+    }
+
+    @Test
+    fun `when the screen fails to load the error is surfaced`() = runTest {
+        coEvery { getInitSignatureScreen.invoke() } returns Result.failure(Throwable())
+
+        viewModel = InitSignatureViewModel(
+            getInitSignatureScreen,
+            searchDocument,
+            logoutCurrentUser
+        )
+
+        Assert.assertEquals(SERVER_ERROR_TITLE, viewModel.uiState.infoEvent?.title)
+        Assert.assertEquals(false, viewModel.uiState.isLoading)
+    }
+
+    @Test
+    fun `an unvalidated document is never sent to the backend`() = runTest {
+        viewModel = givenScreenLoads()
+        viewModel.withTypedDocument(validated = false)
+
+        viewModel.searchDocument()
+
+        // The field is flagged so the form can show why nothing happened, but the search
+        // itself must not go out - and the screen must not move on.
+        Assert.assertEquals(true, viewModel.uiState.validateFields)
+        Assert.assertEquals(null, viewModel.uiState.navigationModel)
+        Assert.assertEquals(false, viewModel.uiState.isLoading)
+        coVerify(exactly = 0) { searchDocument.invoke(any()) }
+    }
+
+    @Test
+    fun `a found document carries the identifier into the signature screen`() = runTest {
+        viewModel = givenScreenLoads()
+        viewModel.withTypedDocument(validated = true)
+        coEvery { searchDocument.invoke(DOCUMENT) } returns Result.success(Unit)
+
+        viewModel.searchDocument()
+
+        Assert.assertEquals(DOCUMENT, viewModel.uiState.navigationModel?.document)
+        Assert.assertEquals(false, viewModel.uiState.isLoading)
+        Assert.assertEquals(null, viewModel.uiState.infoEvent)
+    }
+
+    @Test
+    fun `a document that cannot be found leaves the user on the screen`() = runTest {
+        viewModel = givenScreenLoads()
+        viewModel.withTypedDocument(validated = true)
+        coEvery { searchDocument.invoke(DOCUMENT) } returns Result.failure(Throwable())
+
+        viewModel.searchDocument()
+
+        Assert.assertEquals(SERVER_ERROR_TITLE, viewModel.uiState.infoEvent?.title)
+        Assert.assertEquals(null, viewModel.uiState.navigationModel)
+        Assert.assertEquals(false, viewModel.uiState.isLoading)
+    }
+
+    @Test
+    fun `when goBack is called the navigation asks to go back`() = runTest {
+        viewModel = givenScreenLoads()
+
+        viewModel.goBack()
+
+        Assert.assertEquals(true, viewModel.uiState.navigationModel?.back)
+    }
+
+    @Test
+    fun `when the navigation event is consumed the destination is cleared`() = runTest {
+        viewModel = givenScreenLoads()
+        viewModel.goBack()
+
+        viewModel.consumeNavigationEvent()
+
+        Assert.assertEquals(null, viewModel.uiState.navigationModel)
+        Assert.assertEquals(false, viewModel.uiState.isLoading)
+    }
+
+    @Test
+    fun `the re-auth banner logs the user out and announces it`() = runTest {
+        viewModel = givenScreenLoads()
+        coEvery { logoutCurrentUser.invoke() } returns Result.success(USERNAME)
+
+        viewModel.handleEvent(
+            FooterUiAction.FooterButton(LoginIdentifier.LOGIN_RE_AUTH_BANNER.name)
+        )
+
+        coVerify { logoutCurrentUser.invoke() }
+        verify { UnauthorizedEventHandler.publishUnauthorizedEvent(USERNAME) }
+    }
+
+    @Test
+    fun `a failed logout still announces it so the user is not stranded`() = runTest {
+        viewModel = givenScreenLoads()
+        coEvery { logoutCurrentUser.invoke() } returns Result.failure(Throwable("boom"))
+
+        viewModel.handleEvent(
+            FooterUiAction.FooterButton(LoginIdentifier.LOGIN_RE_AUTH_BANNER.name)
+        )
+
+        verify { UnauthorizedEventHandler.publishUnauthorizedEvent(any()) }
+    }
+
+    @Test
+    fun `any other action only dismisses the banner`() = runTest {
+        coEvery { getInitSignatureScreen.invoke() } returns Result.failure(Throwable())
+        viewModel = InitSignatureViewModel(
+            getInitSignatureScreen,
+            searchDocument,
+            logoutCurrentUser
+        )
+
+        viewModel.handleEvent(GenericUiAction.DismissAction)
+
+        Assert.assertEquals(null, viewModel.uiState.infoEvent)
+        coVerify(exactly = 0) { logoutCurrentUser.invoke() }
+        verify(exactly = 0) { UnauthorizedEventHandler.publishUnauthorizedEvent(any()) }
+    }
+}


### PR DESCRIPTION
Segunda tanda. De 7 ViewModels sin cobertura bajamos a **5**.

## `InitSignatureViewModel` — 10 tests

Cobertura completa: carga de pantalla en ambos sentidos, búsqueda de documento, `goBack`, consumo de navegación y el banner de re-autenticación.

El que más importa: **un documento sin validar nunca llega al backend**. Se marca el campo para que el formulario pueda explicar por qué no pasó nada, pero no sale la petición y la pantalla no avanza.

## `AddReportRoleViewModel` — 3 tests

Solo el manejo de eventos, **a propósito**.

Su carga de pantalla corre sobre `viewModelScope.launch(Dispatchers.IO)`, y `MainDispatcherRule` únicamente reemplaza `Main`. Cualquier aserción sobre ese bloque estaría compitiendo contra un hilo real: pasaría o fallaría según el timing, no según el comportamiento. Ese es el peor tipo de test — el que da confianza sin verificar nada.

Cubrirlo requiere inyectar el dispatcher, que es un cambio en código de producción y merece su propio commit. **El motivo quedó escrito arriba del archivo de test**, no en el olvido.

Dos cosas más que noté en ese ViewModel y no toqué acá:
- la rama de error escribe `uiState` **sin** volver a `Main`, mientras la de éxito sí lo hace — inconsistencia entre las dos ramas del mismo bloque
- es el único de los revisados que fija el dispatcher en vez de heredarlo

## Verificación

`lintDebug`, `ktlintCheck`, `detekt`, `testDebugUnitTest`, `verifyPaparazziDebug` ✅

Solo se agregan tests. Versión sin tocar: 2.4.11 (94).

🤖 Generated with [Claude Code](https://claude.com/claude-code)