### PR TITLE
test: cover the wounds and map fragment view models

### DIFF
--- a/app/src/test/java/com/skgtecnologia/sisem/ui/humanbody/wounds/WoundsViewModelTest.kt
+++ b/app/src/test/java/com/skgtecnologia/sisem/ui/humanbody/wounds/WoundsViewModelTest.kt
@@ -1,0 +1,107 @@
+package com.skgtecnologia.sisem.ui.humanbody.wounds
+
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+
+private const val BURN = "Quemadura"
+private const val BRUISE = "Contusión"
+private const val CUT = "Herida cortante"
+private const val FIRST_DEGREE = "Primer grado"
+private const val SECOND_DEGREE = "Segundo grado"
+
+class WoundsViewModelTest {
+
+    private lateinit var viewModel: WoundsViewModel
+
+    @Before
+    fun setup() {
+        viewModel = WoundsViewModel()
+        viewModel.setBurnList(listOf(FIRST_DEGREE, SECOND_DEGREE))
+    }
+
+    @Test
+    fun `selecting a wound adds it to the selection`() {
+        viewModel.updateWoundsList(BRUISE, isSelected = false)
+
+        Assert.assertEquals(listOf(BRUISE), viewModel.uiState.selectedWounds)
+        Assert.assertEquals(false, viewModel.uiState.onBurnSelected)
+    }
+
+    @Test
+    fun `selecting the same wound twice takes it back out`() {
+        viewModel.updateWoundsList(BRUISE, isSelected = false)
+        viewModel.updateWoundsList(BRUISE, isSelected = false)
+
+        Assert.assertEquals(emptyList<String>(), viewModel.uiState.selectedWounds)
+    }
+
+    @Test
+    fun `wounds accumulate independently of each other`() {
+        viewModel.updateWoundsList(BRUISE, isSelected = false)
+        viewModel.updateWoundsList(CUT, isSelected = false)
+
+        Assert.assertEquals(listOf(BRUISE, CUT), viewModel.uiState.selectedWounds)
+    }
+
+    @Test
+    fun `choosing burn opens the degree picker without recording burn itself`() {
+        viewModel.updateWoundsList(BURN, isSelected = true)
+
+        // Burn is a category, not a diagnosis: the flag tells the screen to ask which
+        // degree, and only that answer ends up in the selection.
+        Assert.assertEquals(true, viewModel.uiState.onBurnSelected)
+        Assert.assertEquals(false, viewModel.uiState.selectedWounds.contains(BURN))
+    }
+
+    @Test
+    fun `picking a degree records it`() {
+        viewModel.updateWoundsList(BURN, isSelected = true)
+        viewModel.updateBurnList(SECOND_DEGREE)
+
+        Assert.assertEquals(listOf(SECOND_DEGREE), viewModel.uiState.selectedWounds)
+    }
+
+    @Test
+    fun `changing the degree replaces the previous one instead of piling up`() {
+        viewModel.updateWoundsList(BURN, isSelected = true)
+        viewModel.updateBurnList(FIRST_DEGREE)
+        viewModel.updateBurnList(SECOND_DEGREE)
+
+        Assert.assertEquals(listOf(SECOND_DEGREE), viewModel.uiState.selectedWounds)
+    }
+
+    @Test
+    fun `unchecking burn clears the degree but leaves the other wounds alone`() {
+        viewModel.updateWoundsList(BRUISE, isSelected = false)
+        viewModel.updateWoundsList(BURN, isSelected = true)
+        viewModel.updateBurnList(SECOND_DEGREE)
+
+        viewModel.updateWoundsList(BURN, isSelected = false)
+
+        Assert.assertEquals(listOf(BRUISE), viewModel.uiState.selectedWounds)
+        Assert.assertEquals(false, viewModel.uiState.onBurnSelected)
+    }
+
+    @Test
+    fun `handling the selection resets both the list and the burn flag`() {
+        viewModel.updateWoundsList(BRUISE, isSelected = false)
+        viewModel.updateWoundsList(BURN, isSelected = true)
+
+        viewModel.onSelectedWoundsHandled()
+
+        Assert.assertEquals(emptyList<String>(), viewModel.uiState.selectedWounds)
+        Assert.assertEquals(false, viewModel.uiState.onBurnSelected)
+    }
+
+    @Test
+    fun `the burn flag survives selecting another wound afterwards`() {
+        viewModel.updateWoundsList(BURN, isSelected = true)
+
+        viewModel.updateWoundsList(CUT, isSelected = false)
+
+        // Adding an unrelated wound must not close the degree picker that is still open.
+        Assert.assertEquals(true, viewModel.uiState.onBurnSelected)
+        Assert.assertEquals(listOf(CUT), viewModel.uiState.selectedWounds)
+    }
+}

--- a/app/src/test/java/com/skgtecnologia/sisem/ui/map/MapFragmentViewModelTest.kt
+++ b/app/src/test/java/com/skgtecnologia/sisem/ui/map/MapFragmentViewModelTest.kt
@@ -1,0 +1,82 @@
+package com.skgtecnologia.sisem.ui.map
+
+import com.skgtecnologia.sisem.commons.MainDispatcherRule
+import com.skgtecnologia.sisem.domain.incident.usecases.ObserveActiveIncident
+import com.valkiria.uicomponents.components.incident.model.IncidentUiModel
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class MapFragmentViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @MockK
+    private lateinit var observeActiveIncident: ObserveActiveIncident
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this)
+    }
+
+    /**
+     * Shared WhileSubscribed, so the upstream only runs while something collects. Without
+     * a live collector every assertion would read the initial value and pass for the
+     * wrong reason.
+     */
+    private fun TestScope.subscribedViewModel(): MapFragmentViewModel {
+        val viewModel = MapFragmentViewModel(observeActiveIncident)
+        backgroundScope.keepCollecting(viewModel)
+        return viewModel
+    }
+
+    @Test
+    fun `the state starts without an incident`() = runTest(UnconfinedTestDispatcher()) {
+        every { observeActiveIncident.invoke() } returns flowOf()
+
+        val viewModel = subscribedViewModel()
+
+        Assert.assertEquals(MapFragmentUiState(), viewModel.uiState.value)
+    }
+
+    @Test
+    fun `the active incident is exposed`() = runTest(UnconfinedTestDispatcher()) {
+        val incident = mockk<IncidentUiModel>()
+        every { observeActiveIncident.invoke() } returns flowOf(incident)
+
+        val viewModel = subscribedViewModel()
+
+        Assert.assertEquals(incident, viewModel.uiState.value.incident)
+    }
+
+    @Test
+    fun `closing the incident empties the state`() = runTest(UnconfinedTestDispatcher()) {
+        val incident = mockk<IncidentUiModel>()
+        val incidents = MutableStateFlow<IncidentUiModel?>(incident)
+        every { observeActiveIncident.invoke() } returns incidents
+
+        val viewModel = subscribedViewModel()
+        Assert.assertEquals(incident, viewModel.uiState.value.incident)
+
+        incidents.value = null
+
+        Assert.assertEquals(null, viewModel.uiState.value.incident)
+    }
+}
+
+private fun CoroutineScope.keepCollecting(viewModel: MapFragmentViewModel) {
+    launch { viewModel.uiState.collect { } }
+}


### PR DESCRIPTION
Tercera tanda. De 5 ViewModels sin cobertura bajamos a **3**.

## `WoundsViewModel` — 9 tests

Sin dependencias y sin un solo test, pero con la lógica menos obvia de todas las que llevo revisadas. **Quemadura no es un diagnóstico sino una categoría**, y de ahí sale un comportamiento que no estaba escrito en ningún lado:

- Marcarla **abre el selector de grado sin registrar nada** — `Quemadura` nunca entra a la lista
- Elegir un grado **reemplaza** el anterior en vez de acumularse
- Desmarcarla borra el grado **pero deja intactas las otras heridas**
- Y la bandera sobrevive si después se marca una herida distinta, para no cerrar el selector que sigue abierto

Todo eso sostiene la pantalla y no estaba documentado ni verificado. Los 9 pasaron a la primera, así que los tests describen el comportamiento actual — no lo corrigen.

## `MapFragmentViewModel` — 3 tests

Espeja a `MapViewModel`, colector incluido.

## Estado

Quedan **3**: `SendEmailViewModel`, `MedicalHistoryViewViewModel` (306 líneas, 6 dependencias) y `PreStretcherRetentionViewModel`.

## Verificación

`lintDebug`, `ktlintCheck`, `detekt`, `testDebugUnitTest`, `verifyPaparazziDebug` ✅

Solo se agregan tests. Versión sin tocar: 2.4.11 (94).

🤖 Generated with [Claude Code](https://claude.com/claude-code)