### PR TITLE
test: cover the send email and pre stretcher retention view models

### DIFF
--- a/app/src/test/java/com/skgtecnologia/sisem/ui/sendemail/SendEmailViewModelTest.kt
+++ b/app/src/test/java/com/skgtecnologia/sisem/ui/sendemail/SendEmailViewModelTest.kt
@@ -1,0 +1,176 @@
+package com.skgtecnologia.sisem.ui.sendemail
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.navigation.testing.invoke
+import com.skgtecnologia.sisem.commons.MainDispatcherRule
+import com.skgtecnologia.sisem.commons.SERVER_ERROR_TITLE
+import com.skgtecnologia.sisem.commons.USERNAME
+import com.skgtecnologia.sisem.commons.communication.UnauthorizedEventHandler
+import com.skgtecnologia.sisem.domain.auth.usecases.LogoutCurrentUser
+import com.skgtecnologia.sisem.domain.login.model.LoginIdentifier
+import com.skgtecnologia.sisem.domain.sendemail.usecases.SendEmail
+import com.skgtecnologia.sisem.ui.navigation.AphRoute
+import com.valkiria.uicomponents.action.FooterUiAction
+import com.valkiria.uicomponents.action.GenericUiAction
+import com.valkiria.uicomponents.components.textfield.InputUiModel
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.just
+import io.mockk.mockkObject
+import io.mockk.runs
+import io.mockk.unmockkObject
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+private const val ID_APH = "APH-991"
+private const val RECIPIENT = "medico@sisem.gov.co"
+private const val BODY = "Adjunto la historia clínica."
+
+@RunWith(RobolectricTestRunner::class)
+class SendEmailViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @MockK
+    private lateinit var sendEmail: SendEmail
+
+    @MockK
+    private lateinit var logoutCurrentUser: LogoutCurrentUser
+
+    private val savedStateHandle: SavedStateHandle = SavedStateHandle(
+        route = AphRoute.SendEmailRoute(idAph = ID_APH)
+    )
+
+    private lateinit var viewModel: SendEmailViewModel
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this)
+        mockkObject(UnauthorizedEventHandler)
+        every { UnauthorizedEventHandler.publishUnauthorizedEvent(any()) } just runs
+
+        viewModel = SendEmailViewModel(savedStateHandle, sendEmail, logoutCurrentUser)
+    }
+
+    @After
+    fun teardown() {
+        unmockkObject(UnauthorizedEventHandler)
+    }
+
+    private fun withRecipient(validated: Boolean) {
+        viewModel.emailValue.value = InputUiModel(
+            identifier = "EMAIL",
+            updatedValue = RECIPIENT,
+            fieldValidated = validated
+        )
+        viewModel.bodyValue.value = BODY
+    }
+
+    @Test
+    fun `an unvalidated address is never sent`() = runTest {
+        withRecipient(validated = false)
+
+        viewModel.sendEmail()
+
+        Assert.assertEquals(true, viewModel.uiState.validateFields)
+        Assert.assertEquals(false, viewModel.uiState.isLoading)
+        coVerify(exactly = 0) { sendEmail.invoke(any(), any(), any()) }
+    }
+
+    @Test
+    fun `the email goes out against the record the screen was opened for`() = runTest {
+        withRecipient(validated = true)
+        coEvery { sendEmail.invoke(any(), any(), any()) } returns Result.success(Unit)
+
+        viewModel.sendEmail()
+
+        // idAph comes from the route, not from the form: sending someone else's record
+        // to a doctor would be a clinical error, not just a bug.
+        coVerify { sendEmail.invoke(idAph = ID_APH, to = RECIPIENT, body = BODY) }
+        Assert.assertNotEquals(null, viewModel.uiState.infoEvent)
+        Assert.assertEquals(false, viewModel.uiState.isLoading)
+    }
+
+    @Test
+    fun `a failed send is reported and does not claim success`() = runTest {
+        withRecipient(validated = true)
+        coEvery { sendEmail.invoke(any(), any(), any()) } returns Result.failure(Throwable())
+
+        viewModel.sendEmail()
+
+        Assert.assertEquals(SERVER_ERROR_TITLE, viewModel.uiState.errorEvent?.title)
+        Assert.assertEquals(null, viewModel.uiState.infoEvent)
+        Assert.assertEquals(false, viewModel.uiState.isLoading)
+    }
+
+    @Test
+    fun `cancelling asks to go back`() = runTest {
+        viewModel.cancel()
+
+        Assert.assertEquals(true, viewModel.uiState.navigationModel?.back)
+    }
+
+    @Test
+    fun `navigating to main marks the send as done`() = runTest {
+        viewModel.navigateToMain()
+
+        Assert.assertEquals(true, viewModel.uiState.navigationModel?.send)
+    }
+
+    @Test
+    fun `consuming the navigation event clears the confirmation too`() = runTest {
+        withRecipient(validated = true)
+        coEvery { sendEmail.invoke(any(), any(), any()) } returns Result.success(Unit)
+        viewModel.sendEmail()
+
+        viewModel.consumeNavigationEvent()
+
+        Assert.assertEquals(null, viewModel.uiState.navigationModel)
+        Assert.assertEquals(null, viewModel.uiState.infoEvent)
+        Assert.assertEquals(false, viewModel.uiState.validateFields)
+        Assert.assertEquals(false, viewModel.uiState.isLoading)
+    }
+
+    @Test
+    fun `the re-auth banner logs the user out and announces it`() = runTest {
+        coEvery { logoutCurrentUser.invoke() } returns Result.success(USERNAME)
+
+        viewModel.handleEvent(
+            FooterUiAction.FooterButton(LoginIdentifier.LOGIN_RE_AUTH_BANNER.name)
+        )
+
+        coVerify { logoutCurrentUser.invoke() }
+        verify { UnauthorizedEventHandler.publishUnauthorizedEvent(USERNAME) }
+    }
+
+    @Test
+    fun `a failed logout still announces it so the user is not stranded`() = runTest {
+        coEvery { logoutCurrentUser.invoke() } returns Result.failure(Throwable("boom"))
+
+        viewModel.handleEvent(
+            FooterUiAction.FooterButton(LoginIdentifier.LOGIN_RE_AUTH_BANNER.name)
+        )
+
+        verify { UnauthorizedEventHandler.publishUnauthorizedEvent(any()) }
+    }
+
+    @Test
+    fun `any other action only dismisses the banner`() = runTest {
+        viewModel.handleEvent(GenericUiAction.DismissAction)
+
+        Assert.assertEquals(null, viewModel.uiState.errorEvent)
+        coVerify(exactly = 0) { logoutCurrentUser.invoke() }
+        verify(exactly = 0) { UnauthorizedEventHandler.publishUnauthorizedEvent(any()) }
+    }
+}

--- a/app/src/test/java/com/skgtecnologia/sisem/ui/stretcherretention/pre/PreStretcherRetentionViewModelTest.kt
+++ b/app/src/test/java/com/skgtecnologia/sisem/ui/stretcherretention/pre/PreStretcherRetentionViewModelTest.kt
@@ -1,0 +1,171 @@
+package com.skgtecnologia.sisem.ui.stretcherretention.pre
+
+import com.skgtecnologia.sisem.commons.MainDispatcherRule
+import com.skgtecnologia.sisem.commons.SERVER_ERROR_TITLE
+import com.skgtecnologia.sisem.commons.USERNAME
+import com.skgtecnologia.sisem.commons.communication.UnauthorizedEventHandler
+import com.skgtecnologia.sisem.commons.emptyScreenModel
+import com.skgtecnologia.sisem.domain.auth.usecases.LogoutCurrentUser
+import com.skgtecnologia.sisem.domain.login.model.LoginIdentifier
+import com.skgtecnologia.sisem.domain.stretcherretention.errors.StretchRetentionErrors
+import com.skgtecnologia.sisem.domain.stretcherretention.usecases.GetPreStretcherRetentionScreen
+import com.valkiria.uicomponents.action.FooterUiAction
+import com.valkiria.uicomponents.action.GenericUiAction
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.just
+import io.mockk.mockkObject
+import io.mockk.runs
+import io.mockk.unmockkObject
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+private const val PATIENT = "APH-4471"
+
+class PreStretcherRetentionViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @MockK
+    private lateinit var logoutCurrentUser: LogoutCurrentUser
+
+    @MockK
+    private lateinit var getPreStretcherRetentionScreen: GetPreStretcherRetentionScreen
+
+    private lateinit var viewModel: PreStretcherRetentionViewModel
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this)
+        mockkObject(UnauthorizedEventHandler)
+        every { UnauthorizedEventHandler.publishUnauthorizedEvent(any()) } just runs
+    }
+
+    @After
+    fun teardown() {
+        unmockkObject(UnauthorizedEventHandler)
+    }
+
+    private fun createViewModel() = PreStretcherRetentionViewModel(
+        logoutCurrentUser,
+        getPreStretcherRetentionScreen
+    )
+
+    private suspend fun givenScreenLoads(): PreStretcherRetentionViewModel {
+        coEvery { getPreStretcherRetentionScreen.invoke() } returns Result.success(
+            emptyScreenModel
+        )
+        return createViewModel()
+    }
+
+    @Test
+    fun `when the screen loads it is exposed and the loader is cleared`() = runTest {
+        viewModel = givenScreenLoads()
+
+        Assert.assertEquals(emptyScreenModel, viewModel.uiState.screenModel)
+        Assert.assertEquals(false, viewModel.uiState.isLoading)
+        Assert.assertEquals(null, viewModel.uiState.infoEvent)
+    }
+
+    @Test
+    fun `having no incident is not an error but an empty screen`() = runTest {
+        coEvery { getPreStretcherRetentionScreen.invoke() } returns Result.failure(
+            StretchRetentionErrors.NoIncidentId
+        )
+
+        viewModel = createViewModel()
+
+        // A crew with no incident open has nothing to retain a stretcher for. That is a
+        // normal state, so it gets its own screen instead of an error banner.
+        Assert.assertEquals(null, viewModel.uiState.infoEvent)
+        Assert.assertEquals(false, viewModel.uiState.isLoading)
+        Assert.assertNotEquals(null, viewModel.uiState.screenModel)
+        Assert.assertEquals(1, viewModel.uiState.screenModel?.body?.size)
+    }
+
+    @Test
+    fun `any other failure is surfaced as an error`() = runTest {
+        coEvery { getPreStretcherRetentionScreen.invoke() } returns Result.failure(Throwable())
+
+        viewModel = createViewModel()
+
+        Assert.assertEquals(SERVER_ERROR_TITLE, viewModel.uiState.infoEvent?.title)
+        Assert.assertEquals(null, viewModel.uiState.screenModel)
+        Assert.assertEquals(false, viewModel.uiState.isLoading)
+    }
+
+    @Test
+    fun `navigating to the stretcher view carries the patient`() = runTest {
+        viewModel = givenScreenLoads()
+
+        viewModel.navigateToStretcherView(PATIENT)
+
+        Assert.assertEquals(PATIENT, viewModel.uiState.navigationModel?.patientAph)
+    }
+
+    @Test
+    fun `navigating back asks to go back`() = runTest {
+        viewModel = givenScreenLoads()
+
+        viewModel.navigateBack()
+
+        Assert.assertEquals(true, viewModel.uiState.navigationModel?.back)
+    }
+
+    @Test
+    fun `when the navigation event is consumed the destination is cleared`() = runTest {
+        viewModel = givenScreenLoads()
+        viewModel.navigateBack()
+
+        viewModel.consumeNavigationEvent()
+
+        Assert.assertEquals(null, viewModel.uiState.navigationModel)
+        Assert.assertEquals(false, viewModel.uiState.isLoading)
+    }
+
+    @Test
+    fun `the re-auth banner logs the user out and announces it`() = runTest {
+        viewModel = givenScreenLoads()
+        coEvery { logoutCurrentUser.invoke() } returns Result.success(USERNAME)
+
+        viewModel.handleEvent(
+            FooterUiAction.FooterButton(LoginIdentifier.LOGIN_RE_AUTH_BANNER.name)
+        )
+
+        coVerify { logoutCurrentUser.invoke() }
+        verify { UnauthorizedEventHandler.publishUnauthorizedEvent(USERNAME) }
+    }
+
+    @Test
+    fun `a failed logout still announces it so the user is not stranded`() = runTest {
+        viewModel = givenScreenLoads()
+        coEvery { logoutCurrentUser.invoke() } returns Result.failure(Throwable("boom"))
+
+        viewModel.handleEvent(
+            FooterUiAction.FooterButton(LoginIdentifier.LOGIN_RE_AUTH_BANNER.name)
+        )
+
+        verify { UnauthorizedEventHandler.publishUnauthorizedEvent(any()) }
+    }
+
+    @Test
+    fun `any other action only dismisses the banner`() = runTest {
+        coEvery { getPreStretcherRetentionScreen.invoke() } returns Result.failure(Throwable())
+        viewModel = createViewModel()
+
+        viewModel.handleEvent(GenericUiAction.DismissAction)
+
+        Assert.assertEquals(null, viewModel.uiState.infoEvent)
+        coVerify(exactly = 0) { logoutCurrentUser.invoke() }
+        verify(exactly = 0) { UnauthorizedEventHandler.publishUnauthorizedEvent(any()) }
+    }
+}


### PR DESCRIPTION
Cuarta tanda. Queda **1** ViewModel sin cobertura: `MedicalHistoryViewViewModel`.

## `SendEmailViewModel` — 9 tests

- La dirección se valida **antes** de que salga nada
- **El identificador de la historia viene de la ruta, no del formulario.** Mandarle a un médico la historia de otro paciente no es un bug, es un error clínico — vale dejarlo clavado con un test
- Un envío fallido reporta el error y **no** muestra la confirmación de éxito

## `PreStretcherRetentionViewModel` — 9 tests

La rama que importa es `NoIncidentId`, que **a propósito no se trata como error**. Una tripulación sin incidencia abierta no tiene para qué retener una camilla: ese caso arma su propia pantalla vacía, mientras cualquier otra falla sí levanta el banner.

Ese comportamiento no estaba dicho en ningún lado. Si alguien "simplifica" ese `if` pensando que es ruido, rompe la pantalla sin que nada se lo avise.

## Recuento

De los 9 ViewModels sin cobertura del barrido inicial queda **uno**: `MedicalHistoryViewViewModel` — 306 líneas y 6 dependencias, va en su propio PR.

## Verificación

`lintDebug`, `ktlintCheck`, `detekt`, `testDebugUnitTest`, `verifyPaparazziDebug` ✅

Solo se agregan tests. Versión sin tocar: 2.4.11 (94).

🤖 Generated with [Claude Code](https://claude.com/claude-code)